### PR TITLE
Add basic tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func TestFileExistsExact(t *testing.T) {
+    dir := t.TempDir()
+    name := "test.txt"
+    path := filepath.Join(dir, name)
+    if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+        t.Fatalf("failed to create file: %v", err)
+    }
+    exists, err := FileExistsExact(dir, name)
+    if err != nil {
+        t.Fatalf("FileExistsExact error: %v", err)
+    }
+    if !exists {
+        t.Errorf("expected file to exist")
+    }
+}
+
+func TestSearchFilesByPattern(t *testing.T) {
+    dir := t.TempDir()
+    os.WriteFile(filepath.Join(dir, "a.txt"), []byte(""), 0644)
+    os.WriteFile(filepath.Join(dir, "b.txt"), []byte(""), 0644)
+
+    files, err := SearchFilesByPattern(dir, "*.txt")
+    if err != nil {
+        t.Fatalf("SearchFilesByPattern error: %v", err)
+    }
+    if len(files) != 2 {
+        t.Errorf("expected 2 files, got %d", len(files))
+    }
+}
+
+func TestDeleteFilesByPattern(t *testing.T) {
+    dir := t.TempDir()
+    f1 := filepath.Join(dir, "a.txt")
+    f2 := filepath.Join(dir, "b.txt")
+    os.WriteFile(f1, []byte(""), 0644)
+    os.WriteFile(f2, []byte(""), 0644)
+
+    if err := DeleteFilesByPattern(dir, "*.txt"); err != nil {
+        t.Fatalf("DeleteFilesByPattern error: %v", err)
+    }
+    if _, err := os.Stat(f1); !os.IsNotExist(err) {
+        t.Errorf("expected %s to be removed", f1)
+    }
+    if _, err := os.Stat(f2); !os.IsNotExist(err) {
+        t.Errorf("expected %s to be removed", f2)
+    }
+}
+

--- a/error.md
+++ b/error.md
@@ -1,0 +1,4 @@
+# Issues Found
+
+- Several source files have a trailing dash in the filename (e.g. `api/api.go-`, `v1rpc/rule_pb.go-`). Files ending with `.go-` are ignored by the Go toolchain and therefore the packages under `v1rpc` are not built or tested.
+- Package `config` initializes global configuration inside `init()` which depends on an external file. Tests relying on this package may be affected by environment setup.

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+    "os"
+    "path/filepath"
+    "reflect"
+    "testing"
+)
+
+func TestSplitFileName(t *testing.T) {
+    got := splitFileName("sample1_S1_L001_R1_001.fastq.gz", []string{"_", ".fastq.gz"})
+    want := []string{"sample1", "S1", "L001", "R1", "001"}
+    if !reflect.DeepEqual(got, want) {
+        t.Errorf("splitFileName mismatch. got %v want %v", got, want)
+    }
+}
+
+func TestGroupFilesAndFilterGroups(t *testing.T) {
+    files := []string{
+        "sample1_S1_L001_R1_001.fastq.gz",
+        "sample1_S1_L002_R1_001.fastq.gz",
+        "sample2_S2_L001_R1_001.fastq.gz",
+    }
+    rs := RuleSet{
+        Delimiter: []string{"_", ".fastq.gz"},
+        RowRules:    RowRules{MatchParts: []int{0,1}},
+        ColumnRules: ColumnRules{MatchParts: []int{2}},
+    }
+    grouped, err := GroupFiles(files, rs)
+    if err != nil {
+        t.Fatalf("GroupFiles returned error: %v", err)
+    }
+    valid, invalid := FilterGroups(grouped, 2)
+    if len(valid) != 1 {
+        t.Errorf("expected 1 valid group, got %d", len(valid))
+    }
+    if len(invalid) != 1 {
+        t.Errorf("expected 1 invalid group, got %d", len(invalid))
+    }
+}
+
+func TestIsValidRuleSet(t *testing.T) {
+    rs := RuleSet{
+        RowRules:    RowRules{MatchParts: []int{0,1}},
+        ColumnRules: ColumnRules{MatchParts: []int{1}},
+    }
+    if IsValidRuleSet(rs) {
+        t.Errorf("expected rule set to be invalid due to duplicate index")
+    }
+}
+
+func TestListFilesExclude(t *testing.T) {
+    dir := t.TempDir()
+    os.WriteFile(filepath.Join(dir, "keep.txt"), []byte(""), 0644)
+    os.WriteFile(filepath.Join(dir, "skip.json"), []byte(""), 0644)
+    os.WriteFile(filepath.Join(dir, "invalid_files"), []byte(""), 0644)
+
+    files, err := ListFilesExclude(dir, []string{"*.json", "invalid_files"})
+    if err != nil {
+        t.Fatalf("ListFilesExclude error: %v", err)
+    }
+    if len(files) != 1 || files[0] != "keep.txt" {
+        t.Errorf("unexpected files: %v", files)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add tests for functions in `api` package
- add tests covering `rules` helpers
- document issues in `error.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fd8c24568832d8704e49dcb31b4cd