### PR TITLE
Add more unit tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,56 +1,133 @@
 package api
 
 import (
-    "os"
-    "path/filepath"
-    "testing"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestFileExistsExact(t *testing.T) {
-    dir := t.TempDir()
-    name := "test.txt"
-    path := filepath.Join(dir, name)
-    if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
-        t.Fatalf("failed to create file: %v", err)
-    }
-    exists, err := FileExistsExact(dir, name)
-    if err != nil {
-        t.Fatalf("FileExistsExact error: %v", err)
-    }
-    if !exists {
-        t.Errorf("expected file to exist")
-    }
+	dir := t.TempDir()
+	name := "test.txt"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	exists, err := FileExistsExact(dir, name)
+	if err != nil {
+		t.Fatalf("FileExistsExact error: %v", err)
+	}
+	if !exists {
+		t.Errorf("expected file to exist")
+	}
 }
 
 func TestSearchFilesByPattern(t *testing.T) {
-    dir := t.TempDir()
-    os.WriteFile(filepath.Join(dir, "a.txt"), []byte(""), 0644)
-    os.WriteFile(filepath.Join(dir, "b.txt"), []byte(""), 0644)
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte(""), 0644)
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte(""), 0644)
 
-    files, err := SearchFilesByPattern(dir, "*.txt")
-    if err != nil {
-        t.Fatalf("SearchFilesByPattern error: %v", err)
-    }
-    if len(files) != 2 {
-        t.Errorf("expected 2 files, got %d", len(files))
-    }
+	files, err := SearchFilesByPattern(dir, "*.txt")
+	if err != nil {
+		t.Fatalf("SearchFilesByPattern error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
 }
 
 func TestDeleteFilesByPattern(t *testing.T) {
-    dir := t.TempDir()
-    f1 := filepath.Join(dir, "a.txt")
-    f2 := filepath.Join(dir, "b.txt")
-    os.WriteFile(f1, []byte(""), 0644)
-    os.WriteFile(f2, []byte(""), 0644)
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(dir, "b.txt")
+	os.WriteFile(f1, []byte(""), 0644)
+	os.WriteFile(f2, []byte(""), 0644)
 
-    if err := DeleteFilesByPattern(dir, "*.txt"); err != nil {
-        t.Fatalf("DeleteFilesByPattern error: %v", err)
-    }
-    if _, err := os.Stat(f1); !os.IsNotExist(err) {
-        t.Errorf("expected %s to be removed", f1)
-    }
-    if _, err := os.Stat(f2); !os.IsNotExist(err) {
-        t.Errorf("expected %s to be removed", f2)
-    }
+	if err := DeleteFilesByPattern(dir, "*.txt"); err != nil {
+		t.Fatalf("DeleteFilesByPattern error: %v", err)
+	}
+	if _, err := os.Stat(f1); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed", f1)
+	}
+	if _, err := os.Stat(f2); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be removed", f2)
+	}
 }
 
+func TestDeleteFiles(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(f1, []byte("a"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := os.WriteFile(f2, []byte("b"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := DeleteFiles([]string{f1, f2}); err != nil {
+		t.Fatalf("DeleteFiles error: %v", err)
+	}
+	if _, err := os.Stat(f1); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be deleted", f1)
+	}
+	if _, err := os.Stat(f2); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be deleted", f2)
+	}
+}
+
+func TestDeleteFiles_Single(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(f, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := DeleteFiles([]string{f}); err != nil {
+		t.Fatalf("DeleteFiles error: %v", err)
+	}
+	if _, err := os.Stat(f); err != nil {
+		t.Errorf("file should not be deleted: %v", err)
+	}
+}
+
+func TestSaveDataBlockToTextFile(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "db.txt")
+	db := &pb.DataBlock{UpdatedAt: timestamppb.Now()}
+	if err := SaveDataBlockToTextFile(out, db); err != nil {
+		t.Fatalf("SaveDataBlockToTextFile error: %v", err)
+	}
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatalf("output not created: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Errorf("expected file to be non-empty")
+	}
+}
+
+func TestSaveDataBlock(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.pb")
+	fb := &pb.FileBlock{
+		BlockId:       "id1",
+		ColumnHeaders: []string{"h"},
+		Rows:          []*pb.Row{{RowNumber: 1, Cells: map[string]string{"h": "v"}}},
+	}
+	if err := SaveDataBlock([]*pb.FileBlock{fb}, out); err != nil {
+		t.Fatalf("SaveDataBlock error: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("output file missing: %v", err)
+	}
+	dbLoaded, err := service.LoadDataBlock(out)
+	if err != nil {
+		t.Fatalf("failed to load datablock: %v", err)
+	}
+	if len(dbLoaded.Blocks) != 1 || dbLoaded.Blocks[0].BlockId != "id1" {
+		t.Errorf("unexpected datablock contents")
+	}
+}

--- a/db/extras_test.go
+++ b/db/extras_test.go
@@ -1,0 +1,15 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractFileNames(t *testing.T) {
+	files := []File{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	got := ExtractFileNames(files)
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExtractFileNames mismatch: got %v want %v", got, want)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveDBFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "test.db")
+	if err := os.WriteFile(f, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	if err := RemoveDBFile(f); err != nil {
+		t.Fatalf("RemoveDBFile error: %v", err)
+	}
+	if _, err := os.Stat(f); !os.IsNotExist(err) {
+		t.Errorf("file should be removed")
+	}
+}

--- a/rules/rules_extra_test.go
+++ b/rules/rules_extra_test.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSaveInvalidFiles(t *testing.T) {
+	dir := t.TempDir()
+	rows := []map[string]string{
+		{"a": "f1"},
+		{"b": "f2"},
+	}
+	if err := SaveInvalidFiles(rows, dir); err != nil {
+		t.Fatalf("SaveInvalidFiles error: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "invalid_files_*.txt"))
+	if err != nil || len(matches) != 1 {
+		t.Fatalf("expected invalid file: %v %v", matches, err)
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("failed to read result: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d", len(lines))
+	}
+}
+
+func TestSaveInvalidFiles_NoRows(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveInvalidFiles(nil, dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "invalid_files_*.txt"))
+	if len(matches) != 0 {
+		t.Errorf("expected no output file, got %d", len(matches))
+	}
+}
+
+func TestExportResultsCSV(t *testing.T) {
+	dir := t.TempDir()
+	result := map[int]map[string]string{
+		0: {"A": "a.txt", "B": "b.txt"},
+		1: {"A": "c.txt", "B": "d.txt"},
+	}
+	headers := []string{"A", "B"}
+	if err := ExportResultsCSV(result, headers, dir); err != nil {
+		t.Fatalf("ExportResultsCSV error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "fileblock.csv"))
+	if err != nil {
+		t.Fatalf("failed to read csv: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(lines))
+	}
+	if !strings.Contains(lines[1], "a.txt") {
+		t.Errorf("csv content unexpected: %v", lines[1])
+	}
+}
+
+func TestLoadRuleSetFromFile(t *testing.T) {
+	dir := t.TempDir()
+	rs := RuleSet{Delimiter: []string{"_"}, Header: []string{"A"}, RowRules: RowRules{MatchParts: []int{0}}, ColumnRules: ColumnRules{MatchParts: []int{0}}}
+	b, err := json.Marshal(rs)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rule.json"), b, 0644); err != nil {
+		t.Fatalf("write rule.json error: %v", err)
+	}
+	loaded, err := LoadRuleSetFromFile(dir)
+	if err != nil {
+		t.Fatalf("LoadRuleSetFromFile error: %v", err)
+	}
+	if loaded.Delimiter[0] != "_" || loaded.Header[0] != "A" {
+		t.Errorf("loaded data mismatch: %+v", loaded)
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for deleting files and saving file blocks
- test removing DB files
- verify ExtractFileNames helper
- test rule helpers for invalid lists, CSV export and ruleset loading

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fe45f1b10832d89c982e26949d074