### PR TITLE
Improve test coverage

### DIFF
--- a/api/api_extra_test.go
+++ b/api/api_extra_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// helper to create rule.json and sample files
+func setupRuleDir(t *testing.T) (string, []string) {
+	t.Helper()
+	dir := t.TempDir()
+	rs := map[string]any{
+		"version":     "1",
+		"delimiter":   []string{"_", ".txt"},
+		"header":      []string{"H1", "H2"},
+		"rowRules":    map[string]any{"matchParts": []int{0}},
+		"columnRules": map[string]any{"matchParts": []int{1}},
+		"sizeRules":   map[string]any{"minSize": 0, "maxSize": 1000},
+	}
+	b, _ := json.Marshal(rs)
+	if err := os.WriteFile(filepath.Join(dir, "rule.json"), b, 0644); err != nil {
+		t.Fatalf("write rule.json: %v", err)
+	}
+	files := []string{"r1_c1.txt", "r1_c2.txt"}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+	return dir, files
+}
+
+func TestGenerateFileBlock(t *testing.T) {
+	dir, files := setupRuleDir(t)
+	fb, err := GenerateFileBlock(dir, files)
+	if err != nil {
+		t.Fatalf("GenerateFileBlock error: %v", err)
+	}
+	if fb.BlockId != dir {
+		t.Errorf("block id mismatch: %s", fb.BlockId)
+	}
+	if len(fb.Rows) != 1 {
+		t.Errorf("expected 1 row, got %d", len(fb.Rows))
+	}
+}
+
+func TestConvertFolderFilesToFileBlocks(t *testing.T) {
+	dir, files := setupRuleDir(t)
+	ff := [][]string{{dir}}
+	ff[0] = append(ff[0], files...)
+	fbs, err := ConvertFolderFilesToFileBlocks(ff, []string{"H1", "H2"})
+	if err != nil {
+		t.Fatalf("ConvertFolderFilesToFileBlocks error: %v", err)
+	}
+	if len(fbs) != 1 {
+		t.Fatalf("expected 1 fileblock, got %d", len(fbs))
+	}
+	if fbs[0].BlockId != dir {
+		t.Errorf("block id mismatch")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempConfig(t *testing.T, data string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadConfig(t *testing.T) {
+	cfgPath := writeTempConfig(t, `{"rootDir":"/tmp","exclusions":["*.txt"]}`)
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if cfg.RootDir != "/tmp" {
+		t.Errorf("RootDir mismatch: %s", cfg.RootDir)
+	}
+	if len(cfg.Exclusions) != 1 || cfg.Exclusions[0] != "*.txt" {
+		t.Errorf("Exclusions mismatch: %v", cfg.Exclusions)
+	}
+}
+
+func TestLoadConfig_DefaultExclusions(t *testing.T) {
+	cfgPath := writeTempConfig(t, `{"rootDir":"/tmp"}`)
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if len(cfg.Exclusions) == 0 {
+		t.Errorf("expected default exclusions")
+	}
+}
+
+func TestLoadConfig_MissingRootDir(t *testing.T) {
+	cfgPath := writeTempConfig(t, `{"exclusions":[]}`)
+	if _, err := LoadConfig(cfgPath); err == nil {
+		t.Errorf("expected error for missing rootDir")
+	}
+}
+
+func TestDefaultConfigPath(t *testing.T) {
+	path := defaultConfigPath()
+	if !strings.HasSuffix(path, filepath.Join("config", "config.json")) {
+		t.Errorf("unexpected default path: %s", path)
+	}
+}

--- a/db/db_utils_extra_test.go
+++ b/db/db_utils_extra_test.go
@@ -1,0 +1,110 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"testing/fstest"
+)
+
+func setupChangeFS() func() {
+	old := sqlFiles
+	sqlFiles = fstest.MapFS{
+		"queries/insert_file.sql":  &fstest.MapFile{Data: []byte("INSERT INTO files VALUES (?,?,?)")},
+		"queries/update_files.sql": &fstest.MapFile{Data: []byte("UPDATE files SET size=? WHERE id=?")},
+		"queries/delete_files.sql": &fstest.MapFile{Data: []byte("DELETE FROM files WHERE id=?")},
+	}
+	return func() { sqlFiles = old }
+}
+
+func TestUpsertDelFile_Added(t *testing.T) {
+	restore := setupChangeFS()
+	defer restore()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	query := "INSERT INTO files VALUES (?,?,?)"
+	mock.ExpectExec(regexp.QuoteMeta(query)).WithArgs(int64(1), "a", int64(10)).WillReturnResult(sqlmock.NewResult(1, 1))
+	fc := FileChange{ChangeType: "added", FolderID: 1, Name: "a", DiskSize: 10}
+	if err := fc.UpsertDelFile(context.Background(), db); err != nil {
+		t.Fatalf("UpsertDelFile error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpsertDelFile_Modified(t *testing.T) {
+	restore := setupChangeFS()
+	defer restore()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	query := "UPDATE files SET size=? WHERE id=?"
+	mock.ExpectExec(regexp.QuoteMeta(query)).WithArgs(int64(5), int64(2)).WillReturnResult(sqlmock.NewResult(1, 1))
+	fc := FileChange{ChangeType: "modified", DiskSize: 5, FileID: 2}
+	if err := fc.UpsertDelFile(context.Background(), db); err != nil {
+		t.Fatalf("UpsertDelFile error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpsertDelFile_Removed(t *testing.T) {
+	restore := setupChangeFS()
+	defer restore()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	query := "DELETE FROM files WHERE id=?"
+	mock.ExpectExec(regexp.QuoteMeta(query)).WithArgs(int64(3)).WillReturnResult(sqlmock.NewResult(1, 1))
+	fc := FileChange{ChangeType: "removed", FileID: 3}
+	if err := fc.UpsertDelFile(context.Background(), db); err != nil {
+		t.Fatalf("UpsertDelFile error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}
+
+func TestUpsertDelFile_Unknown(t *testing.T) {
+	restore := setupChangeFS()
+	defer restore()
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	fc := FileChange{ChangeType: "other"}
+	if err := fc.UpsertDelFile(context.Background(), db); err == nil {
+		t.Fatalf("expected error for unknown type")
+	}
+}
+
+func TestUpsertDelFiles(t *testing.T) {
+	restore := setupChangeFS()
+	defer restore()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock new: %v", err)
+	}
+	q1 := "INSERT INTO files VALUES (?,?,?)"
+	q2 := "UPDATE files SET size=? WHERE id=?"
+	mock.ExpectExec(regexp.QuoteMeta(q1)).WithArgs(int64(1), "a", int64(10)).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(q2)).WithArgs(int64(5), int64(2)).WillReturnResult(sqlmock.NewResult(1, 1))
+	changes := []FileChange{
+		{ChangeType: "added", FolderID: 1, Name: "a", DiskSize: 10},
+		{ChangeType: "modified", DiskSize: 5, FileID: 2},
+	}
+	if err := UpsertDelFiles(context.Background(), db, changes); err != nil {
+		t.Fatalf("UpsertDelFiles error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+}

--- a/db/db_utils_more_test.go
+++ b/db/db_utils_more_test.go
@@ -1,0 +1,124 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGetSubFolders verifies sub directory listing with exclusions.
+func TestGetSubFolders(t *testing.T) {
+	root := t.TempDir()
+	os.Mkdir(filepath.Join(root, "a"), 0755)
+	os.Mkdir(filepath.Join(root, "b"), 0755)
+	os.Mkdir(filepath.Join(root, "skip"), 0755)
+	folders, err := GetSubFolders(root, []string{"skip"})
+	if err != nil {
+		t.Fatalf("GetSubFolders error: %v", err)
+	}
+	if len(folders) != 2 {
+		t.Fatalf("expected 2 folders, got %d", len(folders))
+	}
+}
+
+// TestGetFoldersInfo computes size and file count.
+func TestGetFoldersInfo(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	os.Mkdir(sub, 0755)
+	os.WriteFile(filepath.Join(sub, "f1.txt"), []byte("abc"), 0644)
+	os.WriteFile(filepath.Join(sub, "f2.csv"), []byte("d"), 0644)
+	folders, err := GetFoldersInfo(root, []string{"*.csv"})
+	if err != nil {
+		t.Fatalf("GetFoldersInfo error: %v", err)
+	}
+	if len(folders) != 1 {
+		t.Fatalf("expected 1 folder, got %d", len(folders))
+	}
+	if folders[0].FileCount != 1 || folders[0].TotalSize != 3 {
+		t.Errorf("unexpected folder stats: %+v", folders[0])
+	}
+}
+
+// TestCheckForeignKeysEnabled ensures PRAGMA foreign_keys query works.
+func TestCheckForeignKeysEnabled(t *testing.T) {
+	db, err := ConnectDB("sqlite3", ":memory:", true)
+	if err != nil {
+		t.Fatalf("connect db: %v", err)
+	}
+	defer db.Close()
+	on, err := CheckForeignKeysEnabled(db)
+	if err != nil {
+		t.Fatalf("CheckForeignKeysEnabled error: %v", err)
+	}
+	if !on {
+		t.Errorf("expected foreign keys on")
+	}
+}
+
+// TestClearDatabase deletes all data from folders table.
+func TestClearDatabase(t *testing.T) {
+	db := SetupInMemoryDB(t)
+	// insert simple row
+	_, err := db.Exec("INSERT INTO folders(path) VALUES('p')")
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := ClearDatabase(db); err != nil {
+		t.Fatalf("ClearDatabase error: %v", err)
+	}
+	var n int
+	db.QueryRow("SELECT COUNT(*) FROM folders").Scan(&n)
+	if n != 0 {
+		t.Errorf("expected 0 rows, got %d", n)
+	}
+}
+
+func TestCompareFoldersMatch(t *testing.T) {
+	db := SetupInMemoryDB(t)
+	defer db.Close()
+	root := t.TempDir()
+	sub := filepath.Join(root, "dir")
+	os.Mkdir(sub, 0755)
+	// create file to give size
+	os.WriteFile(filepath.Join(sub, "f1.txt"), []byte("hi"), 0644)
+	// insert folder info in DB matching disk
+	_, err := db.Exec("INSERT INTO folders(path,total_size,file_count) VALUES(?,?,?)", sub, int64(2), int64(1))
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	unchanged, _, diffs, err := CompareFolders(db, root, nil, nil)
+	if err != nil {
+		t.Fatalf("CompareFolders error: %v", err)
+	}
+	if !unchanged || len(diffs) != 0 {
+		t.Errorf("expected no diffs")
+	}
+}
+
+func TestCompareFilesMatch(t *testing.T) {
+	db := SetupInMemoryDB(t)
+	defer db.Close()
+	root := t.TempDir()
+	// folder path
+	folder := root
+	// create file on disk
+	os.WriteFile(filepath.Join(folder, "f1.txt"), []byte("abc"), 0644)
+	// insert folder and file in DB
+	res, err := db.Exec("INSERT INTO folders(path,total_size,file_count) VALUES(?,?,?)", folder, int64(3), int64(1))
+	if err != nil {
+		t.Fatalf("insert folder: %v", err)
+	}
+	fid, _ := res.LastInsertId()
+	_, err = db.Exec("INSERT INTO files(folder_id,name,size) VALUES(?,?,?)", fid, "f1.txt", int64(3))
+	if err != nil {
+		t.Fatalf("insert file: %v", err)
+	}
+	unchanged, _, changes, err := CompareFiles(db, folder, nil)
+	if err != nil {
+		t.Fatalf("CompareFiles error: %v", err)
+	}
+	if !unchanged || len(changes) != 0 {
+		t.Errorf("expected files to match")
+	}
+}


### PR DESCRIPTION
## Summary
- add new tests for config package
- cover GenerateFileBlock and folder conversion helpers
- test DB update helpers with sqlmock
- verify folder utilities and comparison logic

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_683fe76375b4832d8ca168402dc63c3e