### PR TITLE
[codex] add external import guardrail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,16 @@ PKGS_LINT := ./config ./db ./rules ./block ./cmd/...
 PKGS_SECURITY := ./db ./rules ./block
 PKGS_TEST_CORE := ./config ./db ./rules ./block ./cmd/...
 
-.PHONY: test test-core fmt vet lint lint-security vuln vuln-all golangci-lint govulncheck
+.PHONY: test test-core test-guardrail fmt vet lint lint-security vuln vuln-all golangci-lint govulncheck
 
 test:
 	go test -race ./...
 
-test-core:
+test-core: test-guardrail
 	go test -race $(PKGS_TEST_CORE)
+
+test-guardrail:
+	go test . -run TestExternalAPIProtosImportGuardrail
 
 fmt:
 	go fmt ./...

--- a/external_api_protos_import_guardrail_test.go
+++ b/external_api_protos_import_guardrail_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"io/fs"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const externalAPIProtosImport = "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+
+var allowedExternalAPIProtosImportFiles = []string{
+	"block/fileblock.go",
+	"block/fileblock_test.go",
+	"block/merge.go",
+	"block/proto.go",
+	"protoio/protoio.go",
+	"protoio/protoio_test.go",
+	"service/service.go",
+	"service/service_test.go",
+	"transport/grpc/datablock_service.go",
+	"transport/grpc/datablock_service_test.go",
+	"transport/grpc/pb_seam.go",
+}
+
+func TestExternalAPIProtosImportGuardrail(t *testing.T) {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	var found []string
+
+	err := filepath.Walk(".", func(path string, info fs.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if info.IsDir() || filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imp := range file.Imports {
+			if strings.Trim(imp.Path.Value, "\"") == externalAPIProtosImport {
+				found = append(found, filepath.ToSlash(path))
+				break
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo for import guardrail: %v", err)
+	}
+
+	slices.Sort(found)
+
+	for _, path := range found {
+		if !slices.Contains(allowedExternalAPIProtosImportFiles, path) {
+			t.Fatalf("unauthorized external api-protos import found in %s", path)
+		}
+	}
+
+	for _, allowed := range allowedExternalAPIProtosImportFiles {
+		if !slices.Contains(found, allowed) {
+			t.Fatalf("guardrail baseline drift: expected allowed import file %s was not found", allowed)
+		}
+	}
+}


### PR DESCRIPTION
## What changed
Adds a small import diffusion guardrail for the external `api-protos` generated package and wires it into the current core baseline loop.

## Why it changed
The current phase is not broad proto migration. The immediate need is to prevent the existing external generated import from spreading beyond the currently allowed boundary packages before ownership and migration decisions are stronger.

## Impact
`make test-core` now runs a root-level guardrail test first, then continues with the existing core baseline packages.

## Validation
- `make test-core`
