### PR TITLE
[codex] split transport boundary pass

### DIFF
--- a/block/fileblock.go
+++ b/block/fileblock.go
@@ -5,11 +5,9 @@ import (
 	"path/filepath"
 
 	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
-	"github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service"
+	"github.com/seoyhaein/tori/protoio"
 	"github.com/seoyhaein/tori/rules"
 )
-
-//TODO pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys" "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service" 없애는 방향으로
 
 // GenerateFileBlockFromDir 디렉터리 경로를 받아서 FileBlock 객체를 생성하고, 바이너리 protobuf 파일로 저장
 func GenerateFileBlockFromDir(dirPath string) (*pb.FileBlock, error) {
@@ -51,12 +49,12 @@ func GenerateFileBlockFromDir(dirPath string) (*pb.FileBlock, error) {
 	}
 
 	// 8. validMap + headers → FileBlock 객체 생성
-	fb := service.ConvertMapToFileBlock(validMap, ruleSet.Header, dirPath)
+	fb := ConvertMapToFileBlock(validMap, ruleSet.Header, dirPath)
 
 	// 9. FileBlock → 바이너리 protobuf 파일로 저장
 	outPath := filepath.Join(dirPath, filepath.Base(dirPath)+"files.pb")
-	if err := service.SaveProtoToFile(outPath, fb, 0o777); err != nil {
-		return nil, fmt.Errorf("SaveProtoToFile error: %w", err)
+	if err := protoio.SaveMessage(outPath, fb, 0o777); err != nil {
+		return nil, fmt.Errorf("SaveMessage error: %w", err)
 	}
 
 	return fb, nil
@@ -94,11 +92,11 @@ func GenerateFileBlock(filePath string, files []string) (*pb.FileBlock, error) {
 	}
 
 	// blockId 를 filePath 로 잡아둠.
-	fbd := service.ConvertMapToFileBlock(validRows, ruleSet.Header, filePath)
+	fbd := ConvertMapToFileBlock(validRows, ruleSet.Header, filePath)
 	pbName := filepath.Join(filePath, fmt.Sprintf("%sfiles.pb", filepath.Base(filePath)))
-	err = service.SaveProtoToFile(pbName, fbd, 0777)
+	err = protoio.SaveMessage(pbName, fbd, 0777)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save proto to file: %w", err)
+		return nil, fmt.Errorf("failed to save proto message: %w", err)
 	}
 
 	return fbd, nil

--- a/block/fileblock_test.go
+++ b/block/fileblock_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"github.com/seoyhaein/tori/protoio"
 	"github.com/seoyhaein/tori/rules"
 )
 
@@ -48,5 +50,92 @@ func TestGenerateFileBlock_PreservesDuplicateCollisionTypedError(t *testing.T) {
 	entry := dupErr.Entries[0]
 	if entry.ReasonCode != "duplicate_role_in_row" || entry.RoleKey != "R1" {
 		t.Fatalf("expected duplicate structure information to survive wrapping: reason=%q role=%q", entry.ReasonCode, entry.RoleKey)
+	}
+}
+
+func TestGenerateDataBlock_WritesMergedDataBlock(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "datablock.pb")
+	input := []*pb.FileBlock{
+		{BlockId: "block-1"},
+		{BlockId: "block-2"},
+	}
+
+	if err := GenerateDataBlock(input, out); err != nil {
+		t.Fatalf("GenerateDataBlock error: %v", err)
+	}
+
+	dataBlock, err := protoio.LoadDataBlock(out)
+	if err != nil {
+		t.Fatalf("LoadDataBlock error: %v", err)
+	}
+
+	if len(dataBlock.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(dataBlock.Blocks))
+	}
+	if dataBlock.Blocks[0].GetBlockId() != "block-1" || dataBlock.Blocks[1].GetBlockId() != "block-2" {
+		t.Fatalf("unexpected block ids: %q %q", dataBlock.Blocks[0].GetBlockId(), dataBlock.Blocks[1].GetBlockId())
+	}
+	if dataBlock.GetUpdatedAt() == nil {
+		t.Fatalf("expected UpdatedAt to be set")
+	}
+}
+
+func TestConvertMapToFileBlockBuildsStableAssemblyShape(t *testing.T) {
+	rows := map[int]map[string]string{
+		20: {
+			"R2": "sample_L001_R2.fastq.gz",
+			"R1": "sample_L001_R1.fastq.gz",
+		},
+		10: {
+			"R1": "other_L001_R1.fastq.gz",
+		},
+	}
+	headers := []string{"R1", "R2"}
+
+	got := ConvertMapToFileBlock(rows, headers, "block-123")
+	if got == nil {
+		t.Fatalf("expected non-nil FileBlock")
+	}
+	if got.GetBlockId() != "block-123" {
+		t.Fatalf("unexpected block id: %q", got.GetBlockId())
+	}
+	if len(got.GetColumnHeaders()) != 2 || got.GetColumnHeaders()[0] != "R1" || got.GetColumnHeaders()[1] != "R2" {
+		t.Fatalf("unexpected column headers: %#v", got.GetColumnHeaders())
+	}
+	if len(got.GetRows()) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(got.GetRows()))
+	}
+	if got.GetRows()[0].GetRowNumber() != 10 || got.GetRows()[1].GetRowNumber() != 20 {
+		t.Fatalf("unexpected row ordering: %d, %d", got.GetRows()[0].GetRowNumber(), got.GetRows()[1].GetRowNumber())
+	}
+	if got.GetRows()[0].GetCells()["R1"] != "other_L001_R1.fastq.gz" {
+		t.Fatalf("unexpected first row cells: %#v", got.GetRows()[0].GetCells())
+	}
+	if got.GetRows()[1].GetCells()["R1"] != "sample_L001_R1.fastq.gz" || got.GetRows()[1].GetCells()["R2"] != "sample_L001_R2.fastq.gz" {
+		t.Fatalf("unexpected second row cells: %#v", got.GetRows()[1].GetCells())
+	}
+}
+
+func TestMergeFileBlocksFromDataBuildsDataBlockShape(t *testing.T) {
+	input := []*pb.FileBlock{
+		{BlockId: "block-1"},
+		{BlockId: "block-2"},
+	}
+
+	got, err := MergeFileBlocksFromData(input)
+	if err != nil {
+		t.Fatalf("MergeFileBlocksFromData error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil DataBlock")
+	}
+	if got.GetUpdatedAt() == nil {
+		t.Fatalf("expected UpdatedAt to be set")
+	}
+	if len(got.GetBlocks()) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(got.GetBlocks()))
+	}
+	if got.GetBlocks()[0].GetBlockId() != "block-1" || got.GetBlocks()[1].GetBlockId() != "block-2" {
+		t.Fatalf("unexpected merged block ids: %q %q", got.GetBlocks()[0].GetBlockId(), got.GetBlocks()[1].GetBlockId())
 	}
 }

--- a/block/merge.go
+++ b/block/merge.go
@@ -2,10 +2,9 @@ package block
 
 import (
 	"fmt"
-	"os"
 
 	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
-	"github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service"
+	"github.com/seoyhaein/tori/protoio"
 )
 
 // GenerateFBs folderFiles 를 받아서 FileBlock 객체를 생성하고, 바이너리 protobuf 파일로 저장
@@ -36,13 +35,13 @@ func GenerateFBs(folderFiles [][]string) ([]*pb.FileBlock, error) {
 // GenerateDataBlock fileblock 을 병합하여 datablcok 으로 저장
 // outputFile 은 파일이어야 함. 파일이 존재할 경우는 체크 하지 않고 덮어씀.
 func GenerateDataBlock(inputBlocks []*pb.FileBlock, outputFile string) error {
-	dataBlock, err := service.MergeFileBlocksFromData(inputBlocks)
+	dataBlock, err := MergeFileBlocksFromData(inputBlocks)
 	if err != nil {
 		return err
 	}
 
 	// DataBlock 저장
-	if err := service.SaveProtoToFile(outputFile, dataBlock, os.ModePerm); err != nil {
+	if err := protoio.SaveMessage(outputFile, dataBlock, 0o777); err != nil {
 		return fmt.Errorf("failed to save DataBlock: %w", err)
 	}
 

--- a/block/proto.go
+++ b/block/proto.go
@@ -1,0 +1,50 @@
+package block
+
+import (
+	"fmt"
+	"sort"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ConvertMapToFileBlock converts the grouped rules result into a FileBlock.
+func ConvertMapToFileBlock(rows map[int]map[string]string, headers []string, blockID string) *pb.FileBlock {
+	fb := &pb.FileBlock{
+		BlockId:       blockID,
+		ColumnHeaders: headers,
+		Rows:          make([]*pb.Row, 0, len(rows)),
+	}
+
+	indices := make([]int, 0, len(rows))
+	for idx := range rows {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	for _, idx := range indices {
+		cols := rows[idx]
+		row := &pb.Row{
+			RowNumber: int32(idx),
+			Cells:     make(map[string]string, len(cols)),
+		}
+		for colKey, value := range cols {
+			row.Cells[colKey] = value
+		}
+		fb.Rows = append(fb.Rows, row)
+	}
+
+	return fb
+}
+
+// MergeFileBlocksFromData combines FileBlocks into one DataBlock.
+func MergeFileBlocksFromData(inputBlocks []*pb.FileBlock) (*pb.DataBlock, error) {
+	if len(inputBlocks) == 0 {
+		return nil, fmt.Errorf("no input blocks provided")
+	}
+
+	return &pb.DataBlock{
+		UpdatedAt: timestamppb.Now(),
+		Blocks:    inputBlocks,
+	}, nil
+}

--- a/protoio/protoio.go
+++ b/protoio/protoio.go
@@ -1,0 +1,35 @@
+package protoio
+
+import (
+	"fmt"
+	"os"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"google.golang.org/protobuf/proto"
+)
+
+// SaveMessage serializes a protobuf message and writes it to disk.
+func SaveMessage(filePath string, message proto.Message, perm os.FileMode) error {
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("failed to serialize data: %w", err)
+	}
+	if err := os.WriteFile(filePath, data, perm); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+// LoadDataBlock loads a DataBlock protobuf message from disk.
+func LoadDataBlock(filePath string) (*pb.DataBlock, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	db := &pb.DataBlock{}
+	if err := proto.Unmarshal(data, db); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pb.DataBlock: %w", err)
+	}
+	return db, nil
+}

--- a/protoio/protoio_test.go
+++ b/protoio/protoio_test.go
@@ -1,0 +1,74 @@
+package protoio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSaveMessageAndLoadDataBlockRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "datablock.pb")
+	want := &pb.DataBlock{
+		UpdatedAt: timestamppb.Now(),
+		Blocks: []*pb.FileBlock{
+			{BlockId: "block-1"},
+		},
+	}
+
+	if err := SaveMessage(path, want, 0o644); err != nil {
+		t.Fatalf("SaveMessage error: %v", err)
+	}
+
+	got, err := LoadDataBlock(path)
+	if err != nil {
+		t.Fatalf("LoadDataBlock error: %v", err)
+	}
+	if got.GetUpdatedAt() == nil {
+		t.Fatalf("expected UpdatedAt to be set")
+	}
+	if len(got.GetBlocks()) != 1 || got.GetBlocks()[0].GetBlockId() != "block-1" {
+		t.Fatalf("unexpected blocks: %+v", got.GetBlocks())
+	}
+}
+
+func TestSaveMessageSupportsFileBlockBinaryWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fileblock.pb")
+	fileBlock := &pb.FileBlock{
+		BlockId:       "file-block-1",
+		ColumnHeaders: []string{"R1", "R2"},
+	}
+
+	if err := SaveMessage(path, fileBlock, 0o644); err != nil {
+		t.Fatalf("SaveMessage error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected non-empty protobuf file")
+	}
+}
+
+func TestLoadDataBlockReturnsErrorForMissingFile(t *testing.T) {
+	_, err := LoadDataBlock(filepath.Join(t.TempDir(), "missing.pb"))
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+}
+
+func TestLoadDataBlockReturnsErrorForInvalidBinary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "invalid.pb")
+	if err := os.WriteFile(path, []byte("not-a-protobuf"), 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	_, err := LoadDataBlock(path)
+	if err == nil {
+		t.Fatalf("expected error for invalid protobuf binary")
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
-	"github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service"
 	"github.com/seoyhaein/tori/config"
 	dbUtils "github.com/seoyhaein/tori/db"
 	globallog "github.com/seoyhaein/tori/log"
+	"github.com/seoyhaein/tori/protoio"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"os"
@@ -17,7 +17,15 @@ import (
 
 var logger = globallog.Log
 
-// DataBlockCliService encapsulates core folder/database operations for CLI and gRPC.
+// DataBlockService is the transport-agnostic application service contract.
+// CLI/local in-process callers and transport adapters should depend on this interface.
+type DataBlockService interface {
+	GetDataBlock(ctx context.Context, updateAt *timestamppb.Timestamp) (*pb.DataBlock, error)
+	SaveFolders(ctx context.Context) error
+	SyncFolders(ctx context.Context) (bool, error)
+}
+
+// DataBlockCliService encapsulates core folder/database operations without owning a transport.
 type DataBlockCliService struct {
 	db  *sql.DB
 	cfg *config.Config
@@ -77,35 +85,6 @@ func (s *DataBlockCliService) SyncFolders(ctx context.Context) (bool, error) {
 	return dbUtils.SyncFolders(ctx, s.db, s.cfg.RootDir, nil, s.cfg.FilesExclusions)
 }
 
-// DataBlockServer bridges DataBlockCliService with the gRPC interface.
-type DataBlockServer struct {
-	pb.UnimplementedDataBlockServiceServer
-	core *DataBlockCliService
-}
-
-// NewDataBlockServer wraps DataBlockCliService for gRPC.
-func NewDataBlockServer(core *DataBlockCliService) pb.DataBlockServiceServer {
-	return &DataBlockServer{core: core}
-}
-
-// SyncFolders RPC handler.
-/*func (s *DataBlockServer) SyncFolders(ctx context.Context, _ *emptypb.Empty) (*pb.SyncResponse, error) {
-	updated, err := s.core.SyncFolders(ctx)
-	return &pb.SyncResponse{Updated: updated}, err
-}*/
-
-// SaveFolders RPC handler.
-/*func (s *DataBlockServer) SaveFolders(ctx context.Context, _ *emptypb.Empty) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, s.core.SaveFolders(ctx)
-}*/
-
-// GetDataBlock RPC handler.
-/*func (s *DataBlockServer) GetDataBlock(ctx context.Context, req *pb.DataBlockRequest) (*pb.DataBlock, error) {
-	return s.core.GetDataBlock(ctx, req)
-}*/
-
-// TODO 이건 api-proto 프로젝트로 빼자.
-
 // SaveDataBlockToTextFile DataBlockData 텍스트 포맷으로 파일에 저장
 func SaveDataBlockToTextFile(filePath string, data *pb.DataBlock) error {
 	// proto 메시지를 텍스트 포맷으로 변환
@@ -124,5 +103,5 @@ func SaveDataBlockToTextFile(filePath string, data *pb.DataBlock) error {
 }
 
 func LoadDataBlock(filePath string) (*pb.DataBlock, error) {
-	return service.LoadDataBlock(filePath)
+	return protoio.LoadDataBlock(filePath)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -3,531 +3,229 @@ package service
 import (
 	"context"
 	"encoding/json"
-	_ "github.com/mattn/go-sqlite3"
-	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
-	"github.com/seoyhaein/api-protos/gen/go/datablock/ichthys/service"
-	"github.com/seoyhaein/tori/config"
-	d "github.com/seoyhaein/tori/db"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
-	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"github.com/seoyhaein/tori/config"
+	d "github.com/seoyhaein/tori/db"
+	"github.com/seoyhaein/tori/protoio"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// helper to create rule.json and sample files
-func setupRuleDir(t *testing.T) (string, []string) {
+func writeRuleDirFixture(t *testing.T, rootDir string) {
 	t.Helper()
-	dir := t.TempDir()
-	rs := map[string]any{
+
+	ruleDir := filepath.Join(rootDir, "sample_set")
+	if err := os.MkdirAll(ruleDir, 0o755); err != nil {
+		t.Fatalf("mkdir sample_set: %v", err)
+	}
+
+	ruleSet := map[string]any{
 		"version":     "1",
-		"delimiter":   []string{"_", ".txt"},
-		"header":      []string{"H1", "H2"},
-		"rowRules":    map[string]any{"matchParts": []int{0}},
-		"columnRules": map[string]any{"matchParts": []int{1}},
+		"delimiter":   []string{"_", "."},
+		"header":      []string{"R1", "R2"},
+		"rowRules":    map[string]any{"matchParts": []int{0, 1, 2, 4, 5, 6}},
+		"columnRules": map[string]any{"matchParts": []int{3}},
 		"sizeRules":   map[string]any{"minSize": 0, "maxSize": 1000},
 	}
-	b, _ := json.Marshal(rs)
-	if err := os.WriteFile(filepath.Join(dir, "rule.json"), b, 0644); err != nil {
+	data, err := json.Marshal(ruleSet)
+	if err != nil {
+		t.Fatalf("marshal rule set: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ruleDir, "rule.json"), data, 0o644); err != nil {
 		t.Fatalf("write rule.json: %v", err)
 	}
-	files := []string{"r1_c1.txt", "r1_c2.txt"}
-	for _, f := range files {
-		if err := os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644); err != nil {
-			t.Fatalf("write file: %v", err)
+
+	files := []string{
+		"sample1_S1_L001_R1_001.fastq.gz",
+		"sample1_S1_L001_R2_001.fastq.gz",
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(ruleDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write fixture file %s: %v", name, err)
 		}
 	}
-	return dir, files
 }
 
-func TestFileExistsExact(t *testing.T) {
-	dir := t.TempDir()
-	name := "test.txt"
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
-		t.Fatalf("failed to create file: %v", err)
-	}
-	exists, err := FileExistsExact(dir, name)
+func newTestDataBlockService(t *testing.T) (*DataBlockCliService, string) {
+	t.Helper()
+
+	rootDir := t.TempDir()
+	writeRuleDirFixture(t, rootDir)
+
+	dbPath := filepath.Join(rootDir, "file_monitor.db")
+	dbConn, err := d.ConnectDB("sqlite3", dbPath, true)
 	if err != nil {
-		t.Fatalf("FileExistsExact error: %v", err)
+		t.Fatalf("ConnectDB error: %v", err)
 	}
-	if !exists {
-		t.Errorf("expected file to exist")
+	t.Cleanup(func() {
+		if closeErr := dbConn.Close(); closeErr != nil {
+			t.Fatalf("close db: %v", closeErr)
+		}
+	})
+
+	if err := d.InitializeDatabase(dbConn); err != nil {
+		t.Fatalf("InitializeDatabase error: %v", err)
 	}
+
+	cfg := &config.Config{
+		RootDir:         rootDir,
+		FilesExclusions: []string{"*.json", "invalid_files", "*.csv", "*.pb"},
+	}
+	return NewDataBlockCliService(dbConn, cfg), rootDir
 }
 
-func TestSearchFilesByPattern(t *testing.T) {
-	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "a.txt"), []byte(""), 0644)
-	os.WriteFile(filepath.Join(dir, "b.txt"), []byte(""), 0644)
+func writeDataBlockFixture(t *testing.T, rootDir string, updatedAt *timestamppb.Timestamp) *pb.DataBlock {
+	t.Helper()
 
-	files, err := SearchFilesByPattern(dir, "*.txt")
-	if err != nil {
-		t.Fatalf("SearchFilesByPattern error: %v", err)
+	dataBlock := &pb.DataBlock{
+		UpdatedAt: updatedAt,
+		Blocks: []*pb.FileBlock{
+			{
+				BlockId:       "block-1",
+				ColumnHeaders: []string{"R1", "R2"},
+			},
+		},
 	}
-	if len(files) != 2 {
-		t.Errorf("expected 2 files, got %d", len(files))
-	}
-}
 
-func TestDeleteFilesByPattern(t *testing.T) {
-	dir := t.TempDir()
-	f1 := filepath.Join(dir, "a.txt")
-	f2 := filepath.Join(dir, "b.txt")
-	os.WriteFile(f1, []byte(""), 0644)
-	os.WriteFile(f2, []byte(""), 0644)
-
-	if err := DeleteFilesByPattern(dir, "*.txt"); err != nil {
-		t.Fatalf("DeleteFilesByPattern error: %v", err)
+	path := filepath.Join(rootDir, "datablock.pb")
+	if err := protoio.SaveMessage(path, dataBlock, 0o644); err != nil {
+		t.Fatalf("SaveMessage error: %v", err)
 	}
-	if _, err := os.Stat(f1); !os.IsNotExist(err) {
-		t.Errorf("expected %s to be removed", f1)
-	}
-	if _, err := os.Stat(f2); !os.IsNotExist(err) {
-		t.Errorf("expected %s to be removed", f2)
-	}
-}
-
-func TestDeleteFiles(t *testing.T) {
-	dir := t.TempDir()
-	f1 := filepath.Join(dir, "a.txt")
-	f2 := filepath.Join(dir, "b.txt")
-	if err := os.WriteFile(f1, []byte("a"), 0644); err != nil {
-		t.Fatalf("failed to write file: %v", err)
-	}
-	if err := os.WriteFile(f2, []byte("b"), 0644); err != nil {
-		t.Fatalf("failed to write file: %v", err)
-	}
-	if err := DeleteFiles([]string{f1, f2}); err != nil {
-		t.Fatalf("DeleteFiles error: %v", err)
-	}
-	if _, err := os.Stat(f1); !os.IsNotExist(err) {
-		t.Errorf("expected %s to be deleted", f1)
-	}
-	if _, err := os.Stat(f2); !os.IsNotExist(err) {
-		t.Errorf("expected %s to be deleted", f2)
-	}
-}
-
-func TestDeleteFiles_Single(t *testing.T) {
-	dir := t.TempDir()
-	f := filepath.Join(dir, "a.txt")
-	if err := os.WriteFile(f, []byte("data"), 0644); err != nil {
-		t.Fatalf("failed to write file: %v", err)
-	}
-	if err := DeleteFiles([]string{f}); err != nil {
-		t.Fatalf("DeleteFiles error: %v", err)
-	}
-	if _, err := os.Stat(f); err != nil {
-		t.Errorf("file should not be deleted: %v", err)
-	}
+	return dataBlock
 }
 
 func TestSaveDataBlockToTextFile(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "db.txt")
-	db := &pb.DataBlock{UpdatedAt: timestamppb.Now()}
-	if err := SaveDataBlockToTextFile(out, db); err != nil {
+	dataBlock := &pb.DataBlock{UpdatedAt: timestamppb.Now()}
+
+	if err := SaveDataBlockToTextFile(out, dataBlock); err != nil {
 		t.Fatalf("SaveDataBlockToTextFile error: %v", err)
 	}
-	info, err := os.Stat(out)
+
+	data, err := os.ReadFile(out)
 	if err != nil {
-		t.Fatalf("output not created: %v", err)
+		t.Fatalf("read output: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("expected non-empty output file")
+	}
+	if !strings.Contains(string(data), "updated_at") {
+		t.Fatalf("expected textproto output to contain updated_at field")
+	}
+}
+
+func TestLoadDataBlock(t *testing.T) {
+	rootDir := t.TempDir()
+	want := writeDataBlockFixture(t, rootDir, timestamppb.Now())
+
+	got, err := LoadDataBlock(filepath.Join(rootDir, "datablock.pb"))
+	if err != nil {
+		t.Fatalf("LoadDataBlock error: %v", err)
+	}
+	if got.GetUpdatedAt() == nil {
+		t.Fatalf("expected UpdatedAt to be set")
+	}
+	if got.GetBlocks()[0].GetBlockId() != want.GetBlocks()[0].GetBlockId() {
+		t.Fatalf("unexpected block id: %q", got.GetBlocks()[0].GetBlockId())
+	}
+}
+
+func TestGetDataBlockWithoutTimestampReturnsCurrentData(t *testing.T) {
+	svc, rootDir := newTestDataBlockService(t)
+	want := writeDataBlockFixture(t, rootDir, timestamppb.Now())
+
+	got, err := svc.GetDataBlock(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetDataBlock error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected DataBlock, got nil")
+	}
+	if got.GetBlocks()[0].GetBlockId() != want.GetBlocks()[0].GetBlockId() {
+		t.Fatalf("unexpected block id: %q", got.GetBlocks()[0].GetBlockId())
+	}
+}
+
+func TestGetDataBlockWithOlderTimestampReturnsCurrentData(t *testing.T) {
+	svc, rootDir := newTestDataBlockService(t)
+	serverTS := timestamppb.Now()
+	writeDataBlockFixture(t, rootDir, serverTS)
+
+	clientTS := timestamppb.New(serverTS.AsTime().Add(-1))
+	got, err := svc.GetDataBlock(context.Background(), clientTS)
+	if err != nil {
+		t.Fatalf("GetDataBlock error: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected DataBlock, got nil")
+	}
+}
+
+func TestGetDataBlockWithSameTimestampReturnsNil(t *testing.T) {
+	svc, rootDir := newTestDataBlockService(t)
+	serverTS := timestamppb.Now()
+	writeDataBlockFixture(t, rootDir, serverTS)
+
+	got, err := svc.GetDataBlock(context.Background(), serverTS)
+	if err != nil {
+		t.Fatalf("GetDataBlock error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil DataBlock when timestamps are equal")
+	}
+}
+
+func TestGetDataBlockWithNewerTimestampReturnsError(t *testing.T) {
+	svc, rootDir := newTestDataBlockService(t)
+	serverTS := timestamppb.Now()
+	writeDataBlockFixture(t, rootDir, serverTS)
+
+	clientTS := timestamppb.New(serverTS.AsTime().Add(1))
+	got, err := svc.GetDataBlock(context.Background(), clientTS)
+	if err == nil {
+		t.Fatalf("expected error when client datablock is newer")
+	}
+	if got != nil {
+		t.Fatalf("expected nil DataBlock on error")
+	}
+}
+
+func TestSaveFoldersAndSyncFoldersGenerateDataBlock(t *testing.T) {
+	svc, rootDir := newTestDataBlockService(t)
+	ctx := context.Background()
+
+	if err := svc.SaveFolders(ctx); err != nil {
+		t.Fatalf("SaveFolders error: %v", err)
+	}
+
+	updated, err := svc.SyncFolders(ctx)
+	if err != nil {
+		t.Fatalf("SyncFolders error: %v", err)
+	}
+	if !updated {
+		t.Fatalf("expected SyncFolders to report updated=true on first generation")
+	}
+
+	dataBlockPath := filepath.Join(rootDir, "datablock.pb")
+	info, err := os.Stat(dataBlockPath)
+	if err != nil {
+		t.Fatalf("stat datablock.pb: %v", err)
 	}
 	if info.Size() == 0 {
-		t.Errorf("expected file to be non-empty")
+		t.Fatalf("expected datablock.pb to be non-empty")
 	}
-}
 
-func TestSGenerateDataBlock(t *testing.T) {
-	dir := t.TempDir()
-	out := filepath.Join(dir, "out.pb")
-	fb := &pb.FileBlock{
-		BlockId:       "id1",
-		ColumnHeaders: []string{"h"},
-		Rows:          []*pb.Row{{RowNumber: 1, Cells: map[string]string{"h": "v"}}},
-	}
-	if err := GenerateDataBlock([]*pb.FileBlock{fb}, out); err != nil {
-		t.Fatalf("SaveDataBlock error: %v", err)
-	}
-	if _, err := os.Stat(out); err != nil {
-		t.Fatalf("output file missing: %v", err)
-	}
-	dbLoaded, err := service.LoadDataBlock(out)
+	dataBlock, err := LoadDataBlock(dataBlockPath)
 	if err != nil {
-		t.Fatalf("failed to load datablock: %v", err)
+		t.Fatalf("LoadDataBlock error: %v", err)
 	}
-	if len(dbLoaded.Blocks) != 1 || dbLoaded.Blocks[0].BlockId != "id1" {
-		t.Errorf("unexpected datablock contents")
-	}
-}
-
-func TestGenerateFileBlock(t *testing.T) {
-	dir, files := setupRuleDir(t)
-	fb, err := GenerateFileBlock(dir, files)
-	if err != nil {
-		t.Fatalf("GenerateFileBlock error: %v", err)
-	}
-	if fb.BlockId != dir {
-		t.Errorf("block id mismatch: %s", fb.BlockId)
-	}
-	if len(fb.Rows) != 1 {
-		t.Errorf("expected 1 row, got %d", len(fb.Rows))
-	}
-}
-
-/*func TestConvertFolderFilesToFileBlocks(t *testing.T) {
-	dir, files := setupRuleDir(t)
-	ff := [][]string{{dir}}
-	ff[0] = append(ff[0], files...)
-	fbs, err := ConvertFolderFilesToFileBlocks(ff, []string{"H1", "H2"})
-	if err != nil {
-		t.Fatalf("ConvertFolderFilesToFileBlocks error: %v", err)
-	}
-	if len(fbs) != 1 {
-		t.Fatalf("expected 1 fileblock, got %d", len(fbs))
-	}
-	if fbs[0].BlockId != dir {
-		t.Errorf("block id mismatch")
-	}
-}*/
-
-//  1. 폴더 내용과 DB가 동일할 때: SyncFolders는 변경 없음으로 간주하고,
-//     최초 호출 시에도 DataBlock을 생성함을 확인합니다.
-func TestSyncFolders_IdenticalFoldersAndDB(t *testing.T) {
-	// 임시 디렉터리 생성 → RootDir로 설정
-	tmpDir := t.TempDir()
-	origRoot := config.GlobalConfig.RootDir
-	config.GlobalConfig.RootDir = tmpDir
-	defer func() { config.GlobalConfig.RootDir = origRoot }()
-
-	// tmpDir 내부에 initial_folder/a.txt 생성
-	initialFolder := filepath.Join(tmpDir, "initial_folder")
-	if err := os.Mkdir(initialFolder, 0755); err != nil {
-		t.Fatalf("초기 폴더 생성 실패: %v", err)
-	}
-	initialFile := filepath.Join(initialFolder, "a.txt")
-	if err := os.WriteFile(initialFile, []byte("hello initial"), 0644); err != nil {
-		t.Fatalf("초기 파일 생성 실패: %v", err)
-	}
-
-	// DB 파일 경로: tmpDir/file_monitor.db
-	dbPath := filepath.Join(tmpDir, "file_monitor.db")
-
-	// DB 연결 및 초기화
-	dbConn, dbErr := d.ConnectDB("sqlite3", dbPath, true)
-	if dbErr != nil {
-		t.Fatalf("DB 연결 실패: %v", dbErr)
-	}
-	defer dbConn.Close()
-	if dbErr = d.InitializeDatabase(dbConn); dbErr != nil {
-		t.Fatalf("DB 초기화 실패: %v", dbErr)
-	}
-
-	// 서비스 인스턴스 생성
-	f := &DataBlockServiceServerImpl{
-		db:  dbConn,
-		cfg: config.GlobalConfig,
-	}
-	ctx := context.Background()
-
-	// SaveFolders 호출: tmpDir 내부 정보를 DB에 삽입
-	if err := f.SaveFolders(ctx); err != nil {
-		t.Fatalf("SaveFolders 호출 중 오류 발생: %v", err)
-	}
-
-	// 첫 번째 SyncFolders 호출: “DB와 FS(현재 tmpDir)가 동일” → 최초 DataBlock 생성
-	got, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("첫 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got {
-		t.Fatalf("첫 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// datablock.pb가 생성되었는지 확인
-	pbFile := filepath.Join(tmpDir, "datablock.pb")
-	info1, err := os.Stat(pbFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			t.Fatalf("첫 번째 SyncFolders 후 datablock.pb 파일이 생성되지 않았습니다")
-		}
-		t.Fatalf("datablock.pb 상태 확인 중 오류: %v", err)
-	}
-	if info1.Size() == 0 {
-		t.Fatalf("생성된 datablock.pb 파일 크기가 0바이트입니다; 비어 있으면 안 됩니다")
-	}
-
-	// 두 번째 SyncFolders 호출 전 아무 변경 없이 재실행
-	time.Sleep(10 * time.Millisecond) // ModTime 차이를 주기 위해 잠시 대기
-	got2, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("두 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got2 {
-		t.Fatalf("두 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// 두 번째 호출에서는 “DB와 FS가 여전히 동일”이므로 DataBlock 생성 시각이 동일하거나
-	// 업데이트하지 않을 수 있음. 따라서 ModTime가 바뀌지 않아도 무방합니다.
-	info2, err := os.Stat(pbFile)
-	if err != nil {
-		t.Fatalf("두 번째 호출 후 datablock.pb 상태 확인 실패: %v", err)
-	}
-	if !info2.ModTime().Equal(info1.ModTime()) && !info2.ModTime().After(info1.ModTime()) {
-		t.Fatalf(
-			"두 번째 호출 후 datablock.pb 업데이트 시각이 예상 범위를 벗어났습니다 (이전: %v, 이후: %v)",
-			info1.ModTime(), info2.ModTime(),
-		)
-	}
-}
-
-// 2) 폴더 내용과 DB가 다를 때: SyncFolders는 차이를 감지하여 DataBlock을 갱신함을 확인합니다.
-func TestSyncFolders_FoldersAndDBDiffer(t *testing.T) {
-	// 임시 디렉터리 생성 → RootDir로 설정
-	tmpDir := t.TempDir()
-	origRoot := config.GlobalConfig.RootDir
-	config.GlobalConfig.RootDir = tmpDir
-	defer func() { config.GlobalConfig.RootDir = origRoot }()
-
-	// tmpDir 내부에 initial_folder/a.txt 생성
-	initialFolder := filepath.Join(tmpDir, "initial_folder")
-	if err := os.Mkdir(initialFolder, 0755); err != nil {
-		t.Fatalf("초기 폴더 생성 실패: %v", err)
-	}
-	initialFile := filepath.Join(initialFolder, "a.txt")
-	if err := os.WriteFile(initialFile, []byte("hello initial"), 0644); err != nil {
-		t.Fatalf("초기 파일 생성 실패: %v", err)
-	}
-
-	// DB 파일 경로: tmpDir/file_monitor.db
-	dbPath := filepath.Join(tmpDir, "file_monitor.db")
-
-	// DB 연결 및 초기화
-	dbConn, dbErr := d.ConnectDB("sqlite3", dbPath, true)
-	if dbErr != nil {
-		t.Fatalf("DB 연결 실패: %v", dbErr)
-	}
-	defer dbConn.Close()
-	if dbErr = d.InitializeDatabase(dbConn); dbErr != nil {
-		t.Fatalf("DB 초기화 실패: %v", dbErr)
-	}
-
-	// 서비스 인스턴스 생성
-	f := &DataBlockServiceServerImpl{
-		db:  dbConn,
-		cfg: config.GlobalConfig,
-	}
-	ctx := context.Background()
-
-	// SaveFolders 호출: tmpDir 내부 정보를 DB에 삽입
-	if err := f.SaveFolders(ctx); err != nil {
-		t.Fatalf("SaveFolders 호출 중 오류 발생: %v", err)
-	}
-
-	// 첫 번째 SyncFolders 호출: 최초 DataBlock 생성
-	got, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("첫 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got {
-		t.Fatalf("첫 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// datablock.pb가 생성되었는지 확인
-	pbFile := filepath.Join(tmpDir, "datablock.pb")
-	info1, err := os.Stat(pbFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			t.Fatalf("첫 번째 SyncFolders 후 datablock.pb 파일이 생성되지 않았습니다")
-		}
-		t.Fatalf("datablock.pb 상태 확인 중 오류: %v", err)
-	}
-	if info1.Size() == 0 {
-		t.Fatalf("생성된 datablock.pb 파일 크기가 0바이트입니다; 비어 있으면 안 됩니다")
-	}
-
-	// 약간 대기하여 ModTime 차이를 명확히 함
-	time.Sleep(10 * time.Millisecond)
-
-	// tmpDir 내부에 새로운 폴더/파일 생성하여 “DB와 FS가 다르다”시나리오 만듦
-	newFolder := filepath.Join(tmpDir, "new_folder")
-	if err := os.Mkdir(newFolder, 0755); err != nil {
-		t.Fatalf("새 폴더 생성 실패: %v", err)
-	}
-	newFile := filepath.Join(newFolder, "example.txt")
-	if err := os.WriteFile(newFile, []byte("hello world"), 0644); err != nil {
-		t.Fatalf("새 파일 생성 실패: %v", err)
-	}
-
-	// 두 번째 SyncFolders 호출: 변경 있음으로 감지되어 DataBlock 갱신
-	got2, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("두 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got2 {
-		t.Fatalf("두 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// datablock.pb 수정 시각이 업데이트되었는지 확인
-	info2, err := os.Stat(pbFile)
-	if err != nil {
-		t.Fatalf("두 번째 호출 후 datablock.pb 상태 확인 실패: %v", err)
-	}
-	if !info2.ModTime().After(info1.ModTime()) {
-		t.Fatalf(
-			"두 번째 SyncFolders 호출 후에도 datablock.pb가 업데이트되지 않았습니다 (이전: %v, 이후: %v)",
-			info1.ModTime(), info2.ModTime(),
-		)
-	}
-}
-
-// MakeTestFilesA는 지정한 폴더(path)에 직접 파일을 생성
-func MakeTestFilesA(path string) {
-	// 디렉터리 생성 (재귀)
-	if err := os.MkdirAll(path, os.ModePerm); err != nil {
-		logger.Fatalf("Failed to create directory %s: %v", path, err)
-	}
-
-	// 예시 FASTQ 파일 이름
-	fileNames := []string{
-		"SRA_S1_L001_R1_001.fastq.gz",
-		"SRA_S1_L001_R2_001.fastq.gz",
-		"SRA_S1_L002_R1_001.fastq.gz",
-		"SRA_S1_L002_R2_001.fastq.gz",
-	}
-
-	// 파일 생성
-	for _, fileName := range fileNames {
-		filePath := filepath.Join(path, fileName)
-		f, err := os.Create(filePath)
-		if err != nil {
-			logger.Fatalf("Failed to create file %s: %v", filePath, err)
-		}
-		f.Close()
-		logger.Infof("Created file: %s", filePath)
-	}
-}
-
-// WriteRuleJSON은 지정한 디렉터리에 rule.json을 생성
-func WriteRuleJSON(dir string) {
-	rule := `{
-  "version": "1.0.1",
-  "delimiter": ["_", "."],
-  "header": ["R1", "R2"],
-  "rowRules": {
-    "matchParts": [0, 1, 2, 4, 5, 6]
-  },
-  "columnRules": {
-    "matchParts": [3]
-  },
-  "sizeRules": {
-    "minSize": 100,
-    "maxSize": 1048576
-  }
-}`
-	rulePath := filepath.Join(dir, "rule.json")
-	if err := os.WriteFile(rulePath, []byte(rule), 0644); err != nil {
-		logger.Fatalf("Failed to write rule.json at %s: %v", rulePath, err)
-	}
-	logger.Infof("Created rule.json at: %s", rulePath)
-}
-
-func TestSyncFolders_WithRulesAndFiles(t *testing.T) {
-	// 1) 테스트용 임시 디렉터리 생성 → 이것이 “루트 폴더”
-	tmpDir := "/test01" // 일단 그냥 만들어 줬음.
-	origRoot := config.GlobalConfig.RootDir
-	config.GlobalConfig.RootDir = tmpDir
-	defer func() { config.GlobalConfig.RootDir = origRoot }()
-
-	// 1a) tmpDir 바로 아래에 “test_folder” 폴더를 만들고,
-	//     그 안에 테스트 파일들과 rule.json을 생성
-	testFolder := filepath.Join(tmpDir, "test_folder")
-	MakeTestFilesA(testFolder) // tmpDir/test_folder에 FASTQ 파일들 생성
-	WriteRuleJSON(testFolder)  // tmpDir/test_folder/rule.json 생성
-
-	// 2) tmpDir 바로 아래에 datablock.pb가 생성될 것이므로,
-	//    한번도 SyncFolders 호출 전에는 없다.
-	//    DB 파일 경로는 tmpDir/file_monitor.db
-	dbPath := filepath.Join(tmpDir, "file_monitor.db")
-
-	// 3) DB 연결 및 초기화
-	dbConn, dbErr := d.ConnectDB("sqlite3", dbPath, true)
-	if dbErr != nil {
-		t.Fatalf("DB 연결 실패: %v", dbErr)
-	}
-	defer dbConn.Close()
-	if dbErr = d.InitializeDatabase(dbConn); dbErr != nil {
-		t.Fatalf("DB 초기화 실패: %v", dbErr)
-	}
-
-	// 4) 서비스 인스턴스 생성 (cfg.RootDir == tmpDir)
-	f := &DataBlockServiceServerImpl{
-		db:  dbConn,
-		cfg: config.GlobalConfig,
-	}
-	ctx := context.Background()
-
-	// --- 초기 SaveFolders 호출: 루트(tmpDir) 밑에 있는 “test_folder” 내부 정보를 DB에 삽입 ---
-	if err := f.SaveFolders(ctx); err != nil {
-		t.Fatalf("SaveFolders 호출 중 오류 발생: %v", err)
-	}
-
-	// --- 첫 번째 SyncFolders 호출: 최초 실행이므로 datablock.pb를 생성해야 함 ---
-	got, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("첫 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got {
-		t.Fatalf("첫 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// tmpDir/datablock.pb가 생성되었는지 확인
-	pbFile := filepath.Join(tmpDir, "datablock.pb")
-	info1, err := os.Stat(pbFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			t.Fatalf("첫 번째 SyncFolders 후 datablock.pb 파일이 생성되지 않았습니다")
-		}
-		t.Fatalf("datablock.pb 상태 확인 중 오류: %v", err)
-	}
-	if info1.Size() == 0 {
-		t.Fatalf("생성된 datablock.pb 파일 크기가 0바이트입니다; 비어 있으면 안 됩니다")
-	}
-
-	// 약간 대기하여 ModTime 차이를 명확히 함
-	time.Sleep(10 * time.Millisecond)
-
-	// --- 두 번째 호출 전: test_folder 내부에 새 폴더/파일 생성하여 “DB와 FS가 다름” 유발 ---
-	newFolder := filepath.Join(tmpDir, "new_subfolder")
-
-	if err := os.Mkdir(newFolder, 0755); err != nil {
-		t.Fatalf("새 폴더 생성 실패: %v", err)
-	}
-	WriteRuleJSON(newFolder)
-	newFile := filepath.Join(newFolder, "new_sample.fastq.gz")
-	if err := os.WriteFile(newFile, []byte("hello world"), 0644); err != nil {
-		t.Fatalf("새 파일 생성 실패: %v", err)
-	}
-
-	// --- 두 번째 SyncFolders 호출: 변경 있음으로 감지되어 datablock.pb 갱신 ---
-	got2, err := f.SyncFolders(ctx)
-	if err != nil {
-		t.Fatalf("두 번째 SyncFolders 호출 중 오류 발생: %v", err)
-	}
-	if !got2 {
-		t.Fatalf("두 번째 SyncFolders 반환값이 false; true여야 합니다")
-	}
-
-	// tmpDir/datablock.pb의 수정 시각이 업데이트되었는지 확인
-	info2, err := os.Stat(pbFile)
-	if err != nil {
-		t.Fatalf("두 번째 호출 후 datablock.pb 상태 확인 실패: %v", err)
-	}
-	if !info2.ModTime().After(info1.ModTime()) {
-		t.Fatalf(
-			"두 번째 SyncFolders 호출 후에도 datablock.pb가 업데이트되지 않았습니다 (이전: %v, 이후: %v)",
-			info1.ModTime(), info2.ModTime(),
-		)
+	if len(dataBlock.GetBlocks()) == 0 {
+		t.Fatalf("expected generated DataBlock to contain at least one block")
 	}
 }

--- a/transport/grpc/datablock_service.go
+++ b/transport/grpc/datablock_service.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"context"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	appservice "github.com/seoyhaein/tori/service"
+)
+
+// DataBlockServer is the gRPC transport adapter for the app service contract.
+// It owns protobuf request/response translation only.
+type DataBlockServer struct {
+	pb.UnimplementedDataBlockServiceServer
+	core appservice.DataBlockService
+}
+
+func NewDataBlockServer(core appservice.DataBlockService) pb.DataBlockServiceServer {
+	return &DataBlockServer{core: core}
+}
+
+func (s *DataBlockServer) FetchDataBlock(ctx context.Context, req *pb.FetchDataBlockRequest) (*pb.FetchDataBlockResponse, error) {
+	data, err := s.core.GetDataBlock(ctx, req.GetIfModifiedSince())
+	if err != nil {
+		return nil, err
+	}
+
+	return newFetchDataBlockResponse(data), nil
+}

--- a/transport/grpc/datablock_service_test.go
+++ b/transport/grpc/datablock_service_test.go
@@ -1,0 +1,114 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type stubDataBlockService struct {
+	data *pb.DataBlock
+	err  error
+}
+
+func (s stubDataBlockService) GetDataBlock(context.Context, *timestamppb.Timestamp) (*pb.DataBlock, error) {
+	return s.data, s.err
+}
+
+func (s stubDataBlockService) SaveFolders(context.Context) error {
+	return nil
+}
+
+func (s stubDataBlockService) SyncFolders(context.Context) (bool, error) {
+	return false, nil
+}
+
+func TestNewFetchDataBlockResponseNilBuildsNoUpdatePayload(t *testing.T) {
+	resp := newFetchDataBlockResponse(nil)
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+	if resp.GetNoUpdate() == nil {
+		t.Fatalf("expected no_update payload")
+	}
+	if resp.GetDataBlock() != nil {
+		t.Fatalf("expected data_block payload to be empty")
+	}
+	if _, ok := resp.Payload.(*pb.FetchDataBlockResponse_NoUpdate); !ok {
+		t.Fatalf("expected no_update oneof payload, got %T", resp.Payload)
+	}
+	if resp.GetNoUpdate().ProtoReflect().Descriptor().FullName() != (&emptypb.Empty{}).ProtoReflect().Descriptor().FullName() {
+		t.Fatalf("expected emptypb.Empty payload shape")
+	}
+}
+
+func TestNewFetchDataBlockResponseDataBuildsDataBlockPayload(t *testing.T) {
+	data := &pb.DataBlock{
+		UpdatedAt: timestamppb.Now(),
+		Blocks: []*pb.FileBlock{
+			{BlockId: "block-1"},
+		},
+	}
+
+	resp := newFetchDataBlockResponse(data)
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+	if resp.GetDataBlock() == nil {
+		t.Fatalf("expected data_block payload")
+	}
+	if resp.GetNoUpdate() != nil {
+		t.Fatalf("expected no_update payload to be empty")
+	}
+	if _, ok := resp.Payload.(*pb.FetchDataBlockResponse_DataBlock); !ok {
+		t.Fatalf("expected data_block oneof payload, got %T", resp.Payload)
+	}
+	if resp.GetDataBlock() != data {
+		t.Fatalf("expected same data pointer to be forwarded through seam")
+	}
+	if resp.GetDataBlock().GetBlocks()[0].GetBlockId() != "block-1" {
+		t.Fatalf("unexpected block id: %q", resp.GetDataBlock().GetBlocks()[0].GetBlockId())
+	}
+}
+
+func TestFetchDataBlockReturnsNoUpdateWhenServiceReturnsNil(t *testing.T) {
+	server := NewDataBlockServer(stubDataBlockService{})
+
+	resp, err := server.FetchDataBlock(context.Background(), &pb.FetchDataBlockRequest{})
+	if err != nil {
+		t.Fatalf("FetchDataBlock error: %v", err)
+	}
+	if resp.GetNoUpdate() == nil {
+		t.Fatalf("expected no_update payload")
+	}
+	if resp.GetDataBlock() != nil {
+		t.Fatalf("expected data_block payload to be empty")
+	}
+}
+
+func TestFetchDataBlockReturnsDataBlockPayload(t *testing.T) {
+	data := &pb.DataBlock{
+		UpdatedAt: timestamppb.Now(),
+		Blocks: []*pb.FileBlock{
+			{BlockId: "block-1"},
+		},
+	}
+	server := NewDataBlockServer(stubDataBlockService{data: data})
+
+	resp, err := server.FetchDataBlock(context.Background(), &pb.FetchDataBlockRequest{})
+	if err != nil {
+		t.Fatalf("FetchDataBlock error: %v", err)
+	}
+	if resp.GetDataBlock() == nil {
+		t.Fatalf("expected data_block payload")
+	}
+	if resp.GetDataBlock().GetBlocks()[0].GetBlockId() != "block-1" {
+		t.Fatalf("unexpected block id: %q", resp.GetDataBlock().GetBlocks()[0].GetBlockId())
+	}
+	if resp.GetNoUpdate() != nil {
+		t.Fatalf("expected no_update payload to be empty")
+	}
+}

--- a/transport/grpc/pb_seam.go
+++ b/transport/grpc/pb_seam.go
@@ -1,0 +1,23 @@
+package grpc
+
+import (
+	pb "github.com/seoyhaein/api-protos/gen/go/datablock/ichthys"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// newFetchDataBlockResponse keeps gRPC payload assembly inside an adapter-local seam.
+func newFetchDataBlockResponse(data *pb.DataBlock) *pb.FetchDataBlockResponse {
+	if data == nil {
+		return &pb.FetchDataBlockResponse{
+			Payload: &pb.FetchDataBlockResponse_NoUpdate{
+				NoUpdate: &emptypb.Empty{},
+			},
+		}
+	}
+
+	return &pb.FetchDataBlockResponse{
+		Payload: &pb.FetchDataBlockResponse_DataBlock{
+			DataBlock: data,
+		},
+	}
+}


### PR DESCRIPTION
## What changed
Splits the first transport boundary pass into explicit packages and local seams.

- introduces `protoio` as the protobuf file I/O boundary
- introduces `transport/grpc` as the gRPC adapter package
- moves protobuf assembly helpers into `block/proto.go`
- keeps `service` as the transport-agnostic app service boundary
- adds focused tests for service, protoio, block assembly shape, and gRPC adapter seams

## Why it changed
The repository is no longer treating service/gRPC as a monolithic area. This change makes the first transport boundary pass real in code while keeping the current protobuf app contract and narrow remote surface intact.

## Impact
- `service` no longer owns gRPC adapter code directly
- `transport/grpc` owns request/response translation only
- protobuf file load/save is isolated in `protoio`
- block-level protobuf assembly is explicit and regression-locked by tests

## Validation
- `go test ./service ./protoio ./block ./transport/grpc/...`
