### PR TITLE
[codex] document transport and proto boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,28 @@ English: [README.md](README.md) | Korean: [README.ko.md](README.ko.md)
 - Baseline status: **Phase 0 baseline is established for practical development**
 - A-1 status: **Phase A-1 first freeze is completed (A/B/C/D/E)**
 - A-2 status: **minimum duplicate collision error contract is active in `rules.GroupFiles`**
+- Transport boundary status: **first transport boundary pass is in place**
 - Immediate priority: **Track A (File/Data structuring)**
 
 ## Baseline Scope
 - Core green-baseline packages: `config`, `db`, `rules`, `block`, `cmd`
-- `service` is a deferred transport/runtime area and is intentionally excluded from the current core baseline.
+- `service`: app service boundary shared by CLI/in-process and transport adapters
+- `transport/grpc`: gRPC adapter boundary
+- `cmd`: current local/in-process entry path
+- `protoio`: protobuf file I/O boundary
+
+## Current Boundary Notes
+- Current structure already reflects the first boundary pass: `service` owns app orchestration, `transport/grpc` owns RPC translation, `cmd` uses the service path directly, and `protoio` owns protobuf file load/save.
+- `make test-core` remains the Track A core baseline command, but the repository is no longer described as if `service` were a currently broken area.
+- The next architecture task is not broad transport feature expansion. The smaller immediate concern is contract ownership: source `.proto`, generated code, app contract, and transport contract need to be documented more explicitly.
 
 ## Commands
-- `make test-core`: current Phase 0 / Track A core green-baseline command
+- `make test-core` runs the core baseline tests and the external `api-protos` import diffusion guardrail.
 - `make lint`: fail gate for core + cmd scope
 - `make lint-security`: report-only security observation (`sqlclosecheck`, `gosec`) for core scope
 - `make vuln`: report-only vuln scan for core scope
 - `make vuln-all`: report-only vuln scan for all packages
-- `make test`: full repository status check (includes deferred `service` area)
+- `make test`: full repository status check
 
 ## Design Documents
 - [`docs/tori_living_technical_draft_v0.2.md`](docs/tori_living_technical_draft_v0.2.md)
@@ -28,7 +37,10 @@ English: [README.md](README.md) | Korean: [README.ko.md](README.ko.md)
 - [`docs/tori_phase0_environment_setup_checklist_v0.1.md`](docs/tori_phase0_environment_setup_checklist_v0.1.md)
 - [`docs/duplicate_policy_design_note_v0.1.md`](docs/duplicate_policy_design_note_v0.1.md)
 - [`docs/duplicate_policy_contract_v0.1.md`](docs/duplicate_policy_contract_v0.1.md)
+- [`docs/architecture/transport_boundary.md`](docs/architecture/transport_boundary.md)
+- [`docs/architecture/proto_contract_ownership.md`](docs/architecture/proto_contract_ownership.md)
 
 ## Deferred Area (Explicit)
-- `service` tests currently fail due to stale transport/runtime contracts.
-- This is tracked as deferred scope in Phase 0 and is not hidden by `test-core`.
+- Final proto contract ownership is not fixed yet.
+- External `api-protos` usage is still allowed in the current baseline, but it is not yet declared as the final canonical ownership model.
+- Gateway API / GRPCRoute placement, mesh policy, and full protobuf-neutral service DTO separation remain deferred.

--- a/docs/architecture/proto_canonicalization_phase1_note.md
+++ b/docs/architecture/proto_canonicalization_phase1_note.md
@@ -1,0 +1,61 @@
+# Proto Canonicalization Phase 1 Note
+
+## Purpose
+
+이 문서는 Phase 1을 canonical source 선언 단계가 아니라 canonicalization 준비 단계로 고정하기 위한 짧은 note다.
+이번 단계의 목적은 local source candidate를 더 보수적으로 다룰 기준을 세우는 것이지, generated code 재생성이나 import rewrite를 시작하는 것이 아니다.
+
+## Current Baseline
+
+- `service`는 transport-agnostic app service boundary다.
+- `transport/grpc`는 adapter다.
+- `protoio`는 protobuf file I/O boundary다.
+- `service`의 protobuf 반환은 현재 허용된 과도기적 app contract다.
+- remote RPC surface는 deliberately narrow 하다.
+- generated Go code는 source of truth가 아니다.
+- current working judgment는 `local candidate preferred for now` 이다.
+
+## Phase 1 Scope
+
+- local source candidate를 working canonical candidate로 다룰 최소 조건을 고정한다.
+- source `.proto` ownership과 generated/import 문제를 분리해 둔다.
+- external `api-protos` 의존은 기존 boundary 안에서만 유지하고 신규 확산을 막는다.
+
+## Working Canonical Candidate
+
+- 현재 기준에서 [protos/apis.proto](/opt/go/src/github.com/HeaInSeo/tori/protos/apis.proto)는 local source candidate로 가장 자연스럽다.
+- 다만 이것은 final ownership 확정이 아니라, Phase 1에서 준비 대상으로 다루는 working canonical candidate다.
+
+## Promotion Conditions
+
+local source candidate를 working canonical candidate로 더 밀어 올리려면 최소 아래 조건이 필요하다.
+
+- local source 변경 승인 경로를 설명할 수 있어야 한다.
+- local source가 semantic owner 후보라는 근거를 더 확보해야 한다.
+- external usage reality와 ownership evidence를 계속 분리해서 설명할 수 있어야 한다.
+- local source 기준이 app/transport/file I/O 경계를 더 악화시키지 않는다는 설명이 가능해야 한다.
+
+## Generated Code Handling In Phase 1
+
+- generated code path 결정, import rewrite, generated code 재생성은 아직 Phase 2 범위다.
+- Phase 1에서는 source `.proto`와 generated code를 다른 층으로 유지한다.
+- 즉 generated package 사용 현실을 ownership 선언으로 읽지 않는다.
+
+## External Dependency Policy In Phase 1
+
+- external `api-protos` 의존은 즉시 제거하지 않는다.
+- 다만 기존 boundary(`service`, `transport/grpc`, `block`, `protoio`) 안에서만 유지한다.
+- 신규 external proto 의존 확산은 막고, 새 의존이 필요하면 먼저 local boundary를 통해 흡수할 수 있는지 본다.
+
+## Exit Criteria
+
+- `protos/apis.proto`를 working canonical candidate로 다루는 이유를 문서상 더 일관되게 설명할 수 있어야 한다.
+- source ownership 설명과 generated/import 현실 설명이 분리되어 있어야 한다.
+- Phase 2가 다룰 일과 아직 다루지 않을 일이 구분되어 있어야 한다.
+
+## Current Working Conclusion
+
+- Phase 1은 canonical source 선언 단계가 아니라 canonicalization 준비 단계다.
+- `protos/apis.proto`는 가장 자연스러운 local source candidate이지만 final ownership 확정은 아니다.
+- generated code path 정리, import rewrite, 재생성은 아직 Phase 2로 둔다.
+- `service` protobuf 반환 제거, remote surface 확장, bootstrap/ingress/Gateway API 문제는 이번 note 범위 밖이다.

--- a/docs/architecture/proto_canonicalization_phase2_migration_order_note.md
+++ b/docs/architecture/proto_canonicalization_phase2_migration_order_note.md
@@ -1,0 +1,68 @@
+# Proto Canonicalization Phase 2 Migration Order Note
+
+## Purpose
+
+이 문서는 Phase 2에서 generated/import dependency를 어떤 순서로 국소 정리할지 고정하기 위한 짧은 note다.
+이번 문서의 목적은 migration order를 보수적으로 정하는 것이지, source ownership 선언이나 실제 import rewrite를 시작하는 것이 아니다.
+
+## Current Baseline
+
+- source ownership과 generated/import migration은 다른 문제다.
+- `service`는 transport-agnostic app service boundary다.
+- `transport/grpc`는 adapter다.
+- `protoio`는 protobuf file I/O boundary다.
+- `service`의 protobuf 반환은 현재 허용된 과도기적 app contract다.
+- remote RPC surface는 deliberately narrow 하다.
+- external `api-protos` 의존은 기존 boundary 안에서만 유지한다.
+
+## Why Order Matters
+
+- generated/import 경로를 한 번에 바꾸면 boundary 충돌과 churn이 같이 커진다.
+- 바깥쪽 adapter부터 안쪽 app contract 쪽으로 좁혀 들어가야 영향 범위를 더 작게 통제할 수 있다.
+- 특히 `service`는 현재 protobuf 반환을 포함하므로 가장 마지막에 다루는 편이 보수적이다.
+
+## Preferred Local Migration Order
+
+Phase 2의 preferred local migration order는 아래와 같다.
+
+1. `transport/grpc`
+2. `protoio`
+3. `block`
+4. `service`
+
+## Per-Step Rules
+
+- `transport/grpc`
+  - adapter이므로 가장 먼저 다뤄도 core/service boundary를 덜 흔든다.
+- `protoio`
+  - file I/O boundary라 transport 다음의 좁은 단위로 정리하기 쉽다.
+- `block`
+  - pb 타입 조합 책임이 있으므로 `protoio` 다음에 국소 정리한다.
+- `service`
+  - 과도기적 protobuf 반환 app contract를 포함하므로 가장 마지막에 다룬다.
+
+## What Phase 2 Still Does Not Do
+
+- 전면 import rename
+- generated code 대량 재생성
+- remote surface 확장
+- `service` contract 재설계
+- bootstrap/lifecycle, ingress, Gateway API / GRPCRoute 문제 처리
+
+## Entry Conditions
+
+- Phase 1 note 기준으로 local source candidate를 working canonical candidate로 다룰 준비가 되어 있어야 한다.
+- ownership과 migration order가 문서상 분리되어 있어야 한다.
+- external dependency 확산 방지 가드레일이 유지되어 있어야 한다.
+
+## Exit Conditions
+
+- 국소 정리 순서가 문서상 흔들리지 않아야 한다.
+- 각 단계가 boundary conflict를 최소화하는 순서로 읽혀야 한다.
+- `service`를 마지막 단계로 남기는 이유가 계속 유지되어야 한다.
+
+## Current Working Conclusion
+
+- Phase 2는 source ownership 선언 단계가 아니라 generated/import 경로를 국소 정리하는 단계다.
+- preferred order는 `transport/grpc -> protoio -> block -> service` 다.
+- 이 순서는 adapter와 file I/O boundary를 먼저 다루고, 과도기적 protobuf app contract를 가진 `service`를 마지막에 남겨 현재 기준선과 가장 덜 충돌한다.

--- a/docs/architecture/proto_canonicalization_phase2a_transport_grpc_note.md
+++ b/docs/architecture/proto_canonicalization_phase2a_transport_grpc_note.md
@@ -1,0 +1,45 @@
+# Proto Canonicalization Phase 2A Transport gRPC Note
+
+## Purpose
+
+이 문서는 Phase 2의 첫 실행 단위를 `transport/grpc`로 한정하기 위한 작은 note다.
+이번 단계의 목적은 generated/import 전면 교체가 아니라, gRPC adapter 경계에서 가장 작은 확인 단위를 먼저 고정하는 것이다.
+
+## Why transport/grpc comes first
+
+- `transport/grpc`는 adapter이므로 첫 국소 실행 단위로 가장 안전하다.
+- 현재 remote RPC surface가 `FetchDataBlock` 중심의 좁은 surface라서 의미 범위를 작게 유지할 수 있다.
+- adapter 경계는 `service` app contract나 더 안쪽 조합 계층을 직접 흔들지 않고도 검토할 수 있는 바깥쪽 단위다.
+
+## Scope
+
+- `transport/grpc` adapter 경계만 먼저 본다.
+- 현재 `FetchDataBlock` 중심의 narrow remote surface와 충돌하지 않는 범위만 다룬다.
+- generated/import 정리의 첫 확인 단위로서 adapter layer를 읽는 데 한정한다.
+
+## Explicit Non-Goals
+
+- generated/import 전면 교체
+- `service` contract 변경
+- `protoio` 정리
+- `block` 정리
+- bootstrap/lifecycle, ingress, Gateway API / GRPCRoute 문제 처리
+- remote surface 확장
+
+## Success Criteria
+
+- `transport/grpc`를 첫 실행 단위로 두는 이유가 문서상 분명해야 한다.
+- 현재 narrow remote surface와 adapter boundary가 함께 읽혀야 한다.
+- `service`, `protoio`, `block`, infra concern이 이번 단계 범위 밖이라는 점이 분명해야 한다.
+
+## Rollback Criteria
+
+- 이 단계 정의가 `FetchDataBlock` 외 remote surface 확대처럼 읽히면 안 된다.
+- adapter 경계 확인이 `service` contract 변경이나 generated 대량 정리로 오해되면 안 된다.
+- 범위가 `protoio`, `block`, bootstrap/ingress`까지 번지면 이 단계 정의는 다시 줄여야 한다.
+
+## Current Working Conclusion
+
+- `transport/grpc`는 adapter이므로 Phase 2의 첫 국소 실행 단위로 가장 안전하다.
+- 현재 `FetchDataBlock` 중심의 좁은 remote surface 덕분에 의미 범위도 작게 유지할 수 있다.
+- 따라서 이번 단계는 gRPC adapter 경계에서의 작은 확인 단계로 읽고, `service`, `protoio`, `block`, bootstrap/ingress/Gateway API 문제는 다음 범위로 남겨 둔다.

--- a/docs/architecture/proto_contract_ownership.md
+++ b/docs/architecture/proto_contract_ownership.md
@@ -1,0 +1,274 @@
+# Proto Contract Ownership
+
+## 목적
+
+이 문서는 현재 tori에서 proto 관련 ownership을 작은 범위로 고정하기 위한 메모다.
+이번 단계의 목적은 `api-protos`를 바로 흡수하는 것이 아니라, 그 전에 무엇이 source contract이고 무엇이 app/transport boundary인지 먼저 구분하는 것이다.
+
+## 구분해야 할 4개 층
+
+### 1. source `.proto`
+
+- protobuf schema의 원본 정의다.
+- 장기적으로 canonical ownership 후보가 될 수 있는 층이다.
+- 현재 저장소 안의 `protos/apis.proto` 흔적과 외부 `api-protos` generated import가 함께 존재하므로, source ownership은 아직 최종 고정 상태가 아니다.
+
+### 2. generated code
+
+- `.proto`로부터 생성된 Go 타입과 service stub 계층이다.
+- generated code는 source contract의 파생물이지, ownership 자체를 자동으로 결정하지는 않는다.
+- 현재 tori는 외부 `api-protos` generated code에 의존할 수 있지만, 그 사실만으로 외부 저장소가 최종 canonical owner라고 확정되는 것은 아니다.
+
+### 3. app contract
+
+- 현재 `service` 계층이 local/in-process와 transport adapter가 함께 사용하는 app service contract다.
+- 이 층은 transport lifecycle이나 ingress 정책을 소유하지 않는다.
+- 현재 baseline에서는 일부 protobuf 타입 반환이 허용되어 있다. 이는 과도기적 app contract 허용 상태이지, 최종 protobuf-neutral 내부 DTO 목표가 완료되었다는 뜻은 아니다.
+
+### 4. transport contract
+
+- `transport/grpc`가 해석하는 RPC request/response shape다.
+- transport contract는 network exposure와 adapter translation을 위한 층이다.
+- 이 층은 app semantics를 호출하지만, app/service ownership을 대체하지 않는다.
+
+## Current Canonical Candidate
+
+현재 시점의 final decision은 아직 아니다.
+다만 현재 문서 기준선에서는 다음을 **current working assumption**으로 둔다.
+
+- canonical source `.proto`의 우선 후보는 generated Go package가 아니라 source `.proto` 자체다.
+- 그리고 현재 저장소 안에 남아 있는 `protos/apis.proto`는 "무시된 흔적"이 아니라, source ownership을 다시 확인해야 할 local candidate로 취급한다.
+- 반대로 현재 외부 `api-protos` generated import가 널리 사용되고 있다는 사실은, transport/app 구현이 그 generated package에 의존하고 있음을 보여줄 뿐, canonical source ownership을 자동으로 고정하지는 않는다.
+
+즉 현재 preferred direction은 "`source .proto` ownership을 먼저 고정하고, generated package path 문제는 그 다음에 따라오게 둔다"는 것이다.
+
+## Canonical Source Candidate Evaluation Criteria
+
+canonical source `.proto` 후보를 볼 때는 아래 체크리스트를 먼저 적용한다.
+
+- change ownership
+  - 해당 `.proto`를 바꾸는 책임과 승인 경로가 어디에 있는지 본다.
+  - 자주 import된 generated package인지보다, schema 변경을 실제로 소유하고 조정하는 곳이 어디인지가 더 중요하다.
+- meaning ownership
+  - 메시지/서비스 의미를 설명하고 안정화하는 책임이 어디에 있는지 본다.
+  - 단순 배포 편의나 코드 재사용보다, contract 의미를 누가 정의하는지가 우선이다.
+- import reality != ownership
+  - 현재 어떤 generated package가 많이 import되고 있는지는 dependency reality일 뿐이다.
+  - import 빈도나 현재 결합도만으로 canonical ownership을 확정하지 않는다.
+- generated convenience != source authority
+  - generated package가 편리하거나 이미 널리 쓰인다는 사실은 source authority의 증거가 아니다.
+  - source authority는 generated 산출물 바깥의 `.proto` ownership에서 판단한다.
+- boundary preservation
+  - 어떤 후보가 app contract, transport contract, file I/O boundary를 덜 흔들고 유지하게 하는지 본다.
+  - canonical 판단은 편의보다 경계 보존에 유리한 쪽을 우선한다.
+- ownership != migration cost
+  - 나중에 옮기기 쉬운지, import 교체 비용이 작은지는 migration cost 문제다.
+  - migration cost는 참고사항일 뿐이고, ownership 자체를 대신 결정하지 않는다.
+
+## Current Application Of The Criteria
+
+현재 저장소에 위 기준을 적용하면, final decision이 아니라 다음 해석을 **working application note**로 둔다.
+
+- `protos/apis.proto`는 local canonical candidate로 재검토 대상이다.
+  - 이유: local source candidate로서 change ownership과 meaning ownership을 다시 점검할 수 있는 위치이기 때문이다.
+  - 다만 이것만으로 이미 canonical source로 최종 확정되었다고 말하지는 않는다.
+- 외부 `api-protos` generated import는 dependency reality일 뿐 canonical ownership 자동 증거는 아니다.
+  - 현재 `service`, `block`, `transport/grpc`, `protoio`가 그 generated package를 사용하고 있어도, 이는 import reality와 generated convenience를 보여줄 뿐이다.
+  - 따라서 external generated path의 현재 사용량만으로 source authority를 판정하지 않는다.
+- canonical 판단의 1차 기준은 generated package가 아니라 source `.proto`다.
+  - 즉 현재 단계에서는 "`어느 generated path가 더 널리 쓰이는가`"보다 "`어느 source `.proto`가 change/meaning ownership을 더 설명하는가`"를 먼저 본다.
+
+## Evidence Checklist For Canonical Source Ownership
+
+아래 항목은 canonical source ownership 판정을 보조하기 위한 evidence checklist다.
+이 체크리스트는 final decision을 자동으로 내리기 위한 것이 아니라, 어떤 근거가 더 필요한지 좁혀 보기 위한 evaluation aid다.
+
+- change approval path
+  - 해당 `.proto` 변경이 실제로 어떤 저장소와 어떤 승인 경로를 통해 검토/승인되는지 확인한다.
+  - 변경 승인 경로가 불명확하면 canonical ownership evidence도 약한 것으로 본다.
+- meaning stewardship
+  - 메시지와 서비스 의미를 누가 설명하고, 누가 semantic drift를 막고, 누가 contract 변경의 의미를 책임지는지 확인한다.
+  - 단순 유지보수 편의보다 meaning stewardship evidence를 우선 본다.
+- boundary preservation impact
+  - 어떤 후보를 canonical source로 볼 때 app contract, transport contract, file I/O boundary가 덜 흔들리는지 확인한다.
+  - 경계를 불필요하게 섞는 후보는 evidence가 더 강해야 한다.
+- cross-repo dependency shape
+  - 실제 의존이 단일 저장소 중심인지, 다중 저장소에 걸친 shared contract인지, 혹은 한쪽이 파생 소비자인지 확인한다.
+  - 이 항목은 dependency shape를 이해하기 위한 것이지, import 수만 세어 ownership을 확정하기 위한 것이 아니다.
+- source-first consistency
+  - 판단이 generated package 경로가 아니라 source `.proto` 기준으로 일관되게 설명되는지 확인한다.
+  - generated convenience가 source authority를 가리는 경우에는 evidence를 다시 분리해서 본다.
+- migration separation
+  - ownership 판단과 migration 계획을 분리해서 서술할 수 있는지 확인한다.
+  - "옮기기 어려우니 현재 owner로 본다" 같은 식의 논리를 피하고, ownership evidence와 migration cost를 따로 기록한다.
+
+## How To Use This Checklist
+
+- 먼저 candidate마다 위 evidence 항목을 한 줄씩 채운다.
+- 그 다음 change ownership, meaning stewardship, source-first consistency가 가장 선명한 후보가 있는지 본다.
+- boundary preservation impact와 cross-repo dependency shape는 보강 evidence로 사용하되, import usage reality를 ownership evidence와 같은 층으로 취급하지 않는다.
+- migration separation 항목은 "지금 당장 옮길 수 있는가"가 아니라 "ownership 판단이 migration 비용 논리에 오염되지 않았는가"를 확인하는 데 사용한다.
+- evidence가 비어 있거나 약한 경우에는 canonical owner를 확정하지 않고, working assumption 상태를 유지하는 편이 맞다.
+
+## Candidate Comparison Note
+
+이 비교 메모는 final decision이 아니라 현재 evidence 상태를 나란히 놓아 보는 working comparison note다.
+
+### Candidate A: `protos/apis.proto`
+
+- change approval path
+  - local candidate로서 저장소 내부 변경 경로를 직접 점검할 수 있다는 점은 보인다.
+  - 다만 현재 이 파일이 실제 승인 경로의 중심인지에 대한 evidence는 아직 문서상 충분하지 않다.
+- meaning stewardship
+  - local source 후보이므로 의미 소유권을 local 문서/설계와 연결해 재검토할 여지가 있다.
+  - 다만 현재 이 파일이 실제 semantic owner라는 근거는 아직 비어 있다.
+- boundary preservation impact
+  - local source 기준으로 ownership을 정리하면 app/transport/file I/O 경계를 repo 안에서 설명하기 쉬울 가능성은 있다.
+  - 반면 현재 외부 generated import 현실과의 연결 정리는 후속 migration 주제로 남는다.
+- cross-repo dependency shape
+  - local source candidate로 두면 외부 generated dependency와 local source ownership이 분리된 형태가 된다.
+  - 이 분리가 실제 shared contract 구조와 맞는지는 추가 evidence가 필요하다.
+- source-first consistency
+  - source `.proto`를 기준으로 ownership을 본다는 현재 원칙과는 잘 맞는다.
+  - 다만 local source가 canonical이라고 말할 만큼의 추가 근거는 아직 없다.
+- migration separation
+  - ownership 판단과 import migration을 분리해서 생각하기 쉽다.
+  - 다만 실제 migration 부담은 아직 계산하지 않았고, 그것을 ownership 증거로 쓰지도 않는다.
+
+### Candidate B: external `api-protos` source
+
+- change approval path
+  - 현재 external generated package 사용 현실은 보이지만, external source 자체의 승인 경로가 tori 기준에서 어떻게 연결되는지는 아직 문서상 비어 있다.
+  - 따라서 change approval path evidence는 현재로서는 충분히 드러나지 않는다.
+- meaning stewardship
+  - external source가 의미 소유권을 실제로 책임지는지, 아니면 generated distribution 역할에 가까운지는 아직 분명하지 않다.
+  - 현재 import usage만으로 meaning stewardship을 강하게 읽을 수는 없다.
+- boundary preservation impact
+  - external source를 canonical로 볼 경우 cross-repo contract 설명은 단순해질 수 있다.
+  - 하지만 tori 내부 app/transport/file I/O boundary 설명이 더 선명해지는지는 별도 검토가 필요하다.
+- cross-repo dependency shape
+  - 현재 dependency reality상 external generated package가 실제 소비 지점에 널리 연결돼 있다는 점은 보인다.
+  - 그러나 이 사실은 cross-repo dependency shape evidence일 뿐, ownership 결론으로 바로 점프할 수는 없다.
+- source-first consistency
+  - external generated import usage가 많다는 사실만으로는 source-first consistency evidence가 되지 않는다.
+  - external source 자체가 canonical source인지 설명하려면 generated path가 아니라 source ownership 근거가 더 필요하다.
+- migration separation
+  - 현 상태를 유지하는 것이 migration cost 측면에서 편해 보일 수는 있다.
+  - 그러나 그 편의는 ownership evidence가 아니라 migration consideration으로만 남겨 두어야 한다.
+
+## Interim Reading
+
+- 현재 working comparison 기준으로는 local candidate인 `protos/apis.proto`가 배제된 상태가 아니다.
+- 동시에 external `api-protos` generated usage가 많다는 사실만으로 canonical ownership을 확정할 수는 없다.
+- Candidate A는 source-first consistency 측면에서 설명하기 쉬운 부분이 있고, Candidate B는 dependency reality가 더 눈에 띈다.
+- 하지만 두 후보 모두 change approval path와 meaning stewardship evidence는 아직 충분히 문서화되어 있지 않다.
+- 따라서 현재 단계의 읽기는 "external usage가 많으니 외부 owner로 확정"도 아니고, "`protos/apis.proto`가 있으니 local owner로 확정"도 아니다.
+
+## Open Evidence Gaps
+
+canonical source ownership 판정 전에 아직 확인이 비어 있는 근거는 아래 네 가지다.
+
+- source change approval path
+  - 어느 저장소/경로에서 source `.proto` 변경이 실제로 승인되는지 확인이 필요하다.
+- semantic owner evidence
+  - 메시지와 서비스 의미를 누가 설명하고 drift를 막는지 확인이 필요하다.
+- shared-by-design vs reused-in-practice
+  - 이 contract가 원래부터 cross-repo shared source인지, 아니면 현재는 외부 산출물을 재사용하는 상태인지 구분이 필요하다.
+- boundary preservation evidence
+  - 어느 후보가 app/transport/file I/O 경계를 덜 흔드는지에 대한 근거가 더 필요하다.
+
+## Current Use Of These Gaps
+
+- 현재 비교 메모는 위 gap이 남아 있다는 전제 아래에서만 읽어야 한다.
+- 즉 candidate 비교는 "지금 보이는 evidence"를 나란히 놓은 것이고, 위 gap을 메우기 전에는 ownership final decision으로 넘어가지 않는다.
+- 특히 external generated usage 현실은 shared-by-design evidence와 같지 않고, local source 존재만으로 semantic owner evidence가 채워진 것도 아니다.
+
+## Working Candidate Judgment
+
+- 현재 evidence로 local candidate인 `protos/apis.proto` 쪽에 유리한 점은, source-first consistency와 local boundary 설명 측면에서 더 자연스럽다는 것이다.
+- current dependency reality로는 external `api-protos` source 쪽에 실제 generated usage가 넓게 보이지만, 이것은 ownership evidence라기보다 소비 현실에 가깝다.
+- final decision을 막는 핵심 evidence는 아직 change approval path, semantic owner evidence, shared-by-design 여부, boundary preservation evidence 쪽에 남아 있다.
+- 따라서 현재 working conclusion은 `local candidate preferred for now` 이지만, 이는 final ownership 확정이 아니라 현재 evidence만 놓고 본 좁은 judgment note다.
+
+## Generated Code Handling Rule
+
+- generated Go code는 source of truth가 아니다.
+- generated Go code는 `.proto`에서 파생되는 build/toolchain 산출물로 취급한다.
+- 따라서 "어디의 generated package를 import하고 있는가"와 "canonical source `.proto` owner가 어디인가"는 같은 질문으로 다루지 않는다.
+- source `.proto` ownership이 아직 흔들리는 상태에서 generated package path만 보고 canonical owner를 확정했다고 해석하지 않는다.
+
+실무 규칙:
+
+- source contract 판단은 `.proto` 기준으로 한다.
+- generated code 경로 판단은 build/toolchain 및 import migration 기준으로 따로 본다.
+- 두 문제를 한 번에 묶어 결론 내리지 않는다.
+
+## 현재 허용 상태
+
+- 외부 `api-protos` generated code 의존은 현재 baseline에서 허용된다.
+- `service`는 app boundary로 유지되며, 현재는 일부 protobuf 타입을 직접 다룰 수 있다.
+- `transport/grpc`는 protobuf RPC surface를 해석하는 adapter로 남는다.
+- `protoio`는 protobuf file I/O boundary를 담당한다.
+
+## Transitional Import Policy
+
+현재는 전환기이므로 외부 `api-protos` import를 즉시 제거하지 않는다.
+
+기존 import 허용 조건:
+
+- 이미 현재 app/transport/file I/O 경계에서 사용 중인 generated package import는 당분간 유지 가능하다.
+- 단, 이 import가 canonical ownership을 이미 결정한 것처럼 문서나 코드 주석에서 해석되면 안 된다.
+
+신규 proto 관련 의존 추가 시 우선 방향:
+
+- 신규 코드는 먼저 "이 의존이 source `.proto` ownership 문제인지, generated package 사용 문제인지"를 분리해서 판단해야 한다.
+- 가능하면 기존 app boundary와 transport boundary를 더 흐리지 않는 방향을 우선한다.
+- 같은 의미의 새로운 generated package 경로를 병렬로 더 늘리는 식의 추가 의존은 피한다.
+
+기존 import를 언제/왜 바꾸는가:
+
+- 기존 import는 `api-protos` 흡수 구현이 필요해서가 아니라, ownership 기준선이 먼저 고정된 뒤 그 결정에 맞춰 정리할 때 바꾼다.
+- 즉 import 교체의 최소 원칙은 "ownership 결정의 후속 작업"이지, ownership 결정을 import 교체로 대신하지 않는다는 점이다.
+
+## Phase 0 Import Guardrail
+
+- 현재 external `api-protos` import는 이미 사용 중인 경계 안에서만 유지한다.
+- 당분간 신규 proto 관련 external import는 기존 사용 패키지(`service`, `transport/grpc`, `block`, `protoio`) 바깥으로 확산시키지 않는 방향을 기본으로 둔다.
+- 새 의존이 필요해 보일 때는 먼저 local boundary package를 통해 흡수할 수 있는지 검토한다.
+- 이 가드레일의 목적은 즉시 import 제거가 아니라, ownership 결정 전 dependency surface가 더 넓어지는 것을 막는 데 있다.
+
+## 중요한 정리
+
+- 외부 `api-protos` 의존은 현재 허용 상태다.
+- 그러나 이것이 최종 canonical ownership을 자동으로 의미하지는 않는다.
+- canonical ownership은 source `.proto`, generated code 경로, app contract, transport contract를 분리해서 판단해야 한다.
+
+## App Contract vs Transport Contract Boundary
+
+- 현재 `service`의 protobuf 반환은 허용된 과도기적 app contract다.
+- 이 상태는 `service` 책임이 transport adapter 책임으로 재분류되었다는 뜻이 아니다.
+- 즉 protobuf 타입을 사용하더라도, 현재 `service`는 여전히 app/service boundary로 본다.
+- 동시에 이 상태가 최종형이라는 뜻도 아니다.
+- 이후 더 엄격한 contract 분리나 protobuf-neutral 내부 DTO 전환은 후속 선택지로 남아 있다.
+
+## Explicit Non-Decisions
+
+이번 문서는 아직 아래를 결정하지 않는다.
+
+- 최종 canonical `.proto` 위치 확정
+- generated code 최종 디렉터리/패키지 경로 확정
+- `api-protos` 실제 흡수 방식
+- protobuf-neutral 내부 DTO 전환 여부
+- generated code 재생성 방식과 toolchain 절차 확정
+- 기존 import 교체의 실제 실행 순서
+
+## 다음 단계
+
+다음 가장 작은 단계는 `api-protos` 흡수 구현이 아니다.
+그 전에 먼저 아래를 문서 기준선으로 고정해야 한다.
+
+- source `.proto`의 canonical owner가 어디인지
+- generated code를 어떤 저장소/경로에서 관리할지
+- 현재 `service`의 app contract와 `transport/grpc`의 transport contract를 어디까지 분리된 층으로 볼지
+
+즉, 다음 단계는 흡수 설계 전에 ownership을 먼저 고정하는 것이다.

--- a/docs/architecture/remote_rpc_surface_decision_note.md
+++ b/docs/architecture/remote_rpc_surface_decision_note.md
@@ -1,0 +1,70 @@
+# Remote RPC Surface Decision Note
+
+## Purpose
+
+이 문서는 현재 단계에서 어떤 기능을 remote RPC surface로 열고, 어떤 기능은 local-only 또는 deferred로 둘 것인지 작은 범위로 고정하기 위한 note다.
+이번 단계의 목적은 remote contract를 넓히는 것이 아니라, 현재 remote surface를 의도적으로 좁게 유지하는 기준선을 남기는 데 있다.
+
+## Current Baseline
+
+- `service`는 transport-agnostic app service boundary다.
+- `transport/grpc`는 service를 호출하는 adapter다.
+- `cmd`는 현재 local/in-process 진입 경로다.
+- `protoio`는 protobuf file I/O boundary다.
+- 현재 `service`의 protobuf 반환은 허용된 과도기적 app contract다.
+- 현재 `transport/grpc`에서 실제로 adapter shape가 확인되는 항목은 `FetchDataBlock`이다.
+
+## Current Decision
+
+| Surface Item | Current Handling | Note |
+|---|---|---|
+| `FetchDataBlock` | current remote-allowed candidate | 현재 gRPC adapter에서 request/response translation과 테스트 기준선이 이미 존재한다. |
+| `SaveFolders` | local-only for now | 현재는 CLI/in-process 경로에서 쓰는 app operation으로 둔다. |
+| `SyncFolders` | deferred / local-only for now | 현재는 local path 기준으로 유지하고, remote surface로 바로 승격하지 않는다. |
+| gRPC server bootstrap/lifecycle | deferred | 이는 app contract가 아니라 infra/adapter concern으로 둔다. |
+| Gateway API / GRPCRoute attachment | infra concern | core/service 바깥의 attachment 문제로 두고 이번 단계에서 remote contract에 포함하지 않는다. |
+
+## Interpretation Of The Decision
+
+- 현재 remote RPC surface는 deliberately narrow 하다.
+- 이 문서는 "`service`에 메서드가 있으니 모두 remote RPC로 열어야 한다"는 해석을 거부한다.
+- `FetchDataBlock`만 현재 remote-allowed candidate로 두는 것은 adapter 기준선이 이미 확인된 범위만 remote surface로 인정하겠다는 뜻이다.
+- `SaveFolders`와 `SyncFolders`는 현재 app service 계약 안에 존재하지만, 그것만으로 remote contract 승격을 의미하지는 않는다.
+
+## Why This Narrow Surface Is Preferred
+
+- 현재 단계의 우선순위는 transport-agnostic boundary 유지이지 remote 기능 확대가 아니다.
+- 좁은 remote surface는 `service`와 `transport/grpc`의 책임 분리를 더 보수적으로 유지한다.
+- `FetchDataBlock`은 이미 adapter translation과 테스트가 있어 작은 remote candidate로 다루기 적합하다.
+- 반면 folder mutation/sync 계열을 바로 remote surface로 올리면 app contract, infra concern, 운영 정책이 한 번에 섞일 위험이 있다.
+
+## Non-Goals For This Stage
+
+- `SaveFolders`의 remote RPC 승격
+- `SyncFolders`의 remote RPC 승격
+- gRPC server bootstrap/lifecycle 설계 확정
+- Gateway API / GRPCRoute 배치 방식 확정
+- service 시그니처 변경 또는 protobuf-neutral DTO 전환
+
+## Revisit Conditions
+
+- `FetchDataBlock` 외 다른 operation에 대해 adapter-level request/response contract를 별도로 좁게 정의할 필요가 생길 때
+- local-only operation을 remote로 열어야 하는 운영 시나리오가 문서 수준에서 구체화될 때
+- gRPC bootstrap/lifecycle과 Gateway attachment를 infra concern으로 문서화한 뒤, core/service와 분리된 상태에서 surface를 다시 볼 수 있을 때
+
+## Narrow Remote Semantics Note
+
+- 현재 remote surface에서 `FetchDataBlock`은 read-like retrieval semantics 중심으로 본다.
+- 현재 보장 대상으로 읽는 범위는 version/timestamp 계열 retrieval semantics와 충돌하지 않는 범위에 한정한다.
+- mutation/sync orchestration은 아직 remote surface 의미에 포함하지 않는다.
+- `SaveFolders`, `SyncFolders`의 remote execution contract는 아직 범위 밖이다.
+- bootstrap/lifecycle, deployment, ingress, Gateway API / GRPCRoute attachment는 infra concern으로 범위 밖이다.
+
+## Current Working Conclusion
+
+현재 단계의 working conclusion은 다음이다.
+
+- remote RPC surface는 우선 `FetchDataBlock` 중심의 좁은 surface로 유지한다.
+- `SaveFolders`와 `SyncFolders`는 지금은 local-only 또는 deferred로 읽는다.
+- gRPC server bootstrap/lifecycle과 Gateway API / GRPCRoute attachment는 remote contract 자체가 아니라 infra/adapter concern으로 둔다.
+- 따라서 현재는 remote surface를 넓히는 것보다, 좁은 surface를 분명히 유지하는 편이 기준선에 더 맞다.

--- a/docs/architecture/transport_boundary.md
+++ b/docs/architecture/transport_boundary.md
@@ -1,0 +1,132 @@
+# Transport Boundary
+
+## 현재 문제
+
+tori의 현재 구조는 transport 경계가 고정되지 않은 과도기 상태다.
+
+- 직전 구조에서는 `service` 패키지 안에 app service 성격의 로직과 gRPC server adapter 흔적이 같이 있었다.
+- 직전 구조에서는 `cmd`가 local/in-process 호출 경로이지만, transport-agnostic service 사용으로 충분히 명시되지 않았다.
+- `block`은 여전히 proto/generated helper에 직접 의존하므로 core 범위와 proto 경계가 완전히 분리된 상태는 아니다.
+- 저장소 안에는 예전 `protos/apis.proto` 흔적과 외부 generated import가 공존해, transport contract 기준선이 흔들린다.
+
+현재 우선순위는 gRPC 기능 확장이 아니라, transport 변경에도 core/service가 흔들리지 않도록 경계를 먼저 고정하는 것이다.
+
+## Current Baseline
+
+현재 저장소 기준 첫 transport boundary pass는 이미 들어가 있다.
+
+- `service`는 app service boundary다.
+- `transport/grpc`는 service 인터페이스를 호출하는 gRPC adapter다.
+- `cmd`는 현재 local/in-process 경로다.
+- `protoio`는 protobuf file I/O boundary다.
+
+즉 현재 기준선은 "transport를 분리하기 전 상태"가 아니라, "1차 분리를 끝냈지만 ownership 정리가 아직 남은 상태"로 보는 편이 맞다.
+
+## 왜 transport-agnostic core가 필요한지
+
+tori는 앞으로 최소 두 실행 환경을 동시에 고려해야 한다.
+
+- 싱글 머신: CLI, local adapter, in-process 호출
+- Kubernetes: Pod/Service 사이 plain gRPC 통신
+
+그리고 장기적으로는 외부 진입과 내부 통신 정책이 바뀔 수 있다.
+
+- 외부 진입: Gateway API + GRPCRoute 가능성
+- 내부 통신: Istio/mesh 실험 결과에 따라 변경 가능
+
+이 상황에서 core/service가 gRPC나 특정 네트워크 전제에 묶이면 다음 문제가 생긴다.
+
+- CLI/in-process 경로와 remote gRPC 경로가 같은 도메인 동작을 중복 구현하게 된다.
+- transport 교체 시 core/service 수정 범위가 커진다.
+- 향후 Gateway API, mesh, in-cluster Service 모델을 시험할 때 transport 레이어가 아니라 core 레이어까지 흔들린다.
+
+따라서 현재 단계에서는 core/service를 transport-agnostic 하게 두고, transport는 adapter로 한정하는 편이 가장 보수적이다.
+
+## gRPC를 adapter로 남기는 이유
+
+gRPC 자체를 제거하는 것이 목표는 아니다. gRPC는 여전히 Kubernetes 환경에서 다음 이유로 유용하다.
+
+- Pod/Service 간 typed RPC 경로로 사용하기 쉽다.
+- 향후 Gateway API + GRPCRoute와의 연결점이 자연스럽다.
+- protobuf contract를 통해 명시적 경계를 유지하기 쉽다.
+
+다만 gRPC가 core를 소유하면 안 된다.
+
+이번 단계에서 gRPC는 다음 역할만 가진다.
+
+- protobuf request/response를 해석한다.
+- service 인터페이스를 호출한다.
+- transport-specific response shape를 만든다.
+
+즉 gRPC는 transport adapter이고, 도메인 규칙과 실행 정책의 소유자는 아니다.
+
+## local adapter를 두는 이유
+
+싱글 머신 환경에서는 네트워크 hop 없이 같은 service 인터페이스를 바로 호출할 수 있어야 한다.
+
+이 경로가 필요한 이유는 다음과 같다.
+
+- CLI나 단일 프로세스 실행에서 불필요한 gRPC bootstrap을 피할 수 있다.
+- local/in-process 경로가 있으면 transport와 무관하게 service semantics를 검증할 수 있다.
+- 이후 테스트나 임베디드 사용 시 “network를 거치지 않는 adapter”를 제공하기 쉽다.
+
+현재 단계에서는 `cmd -> service interface` 직접 호출을 local/in-process 경로의 기준선으로 본다.
+별도 local network protocol을 설계하지 않는다.
+
+## 싱글 머신 / Kubernetes / Gateway API / Istio 관점의 판단
+
+### 싱글 머신
+
+- 가장 단순한 경로는 in-process 호출이다.
+- `cmd` 또는 local adapter가 service 인터페이스를 바로 호출하면 된다.
+- 이 경로에서는 gRPC가 필수가 아니다.
+
+### Kubernetes
+
+- 현재 단계에서는 plain gRPC over Service면 충분하다.
+- transport/grpc adapter가 service 인터페이스를 호출하고, Kubernetes는 그 adapter를 네트워크로 노출한다.
+- core/service는 cluster 유무를 알 필요가 없다.
+
+### Gateway API + GRPCRoute
+
+- 외부 진입은 장기적으로 gRPC adapter 앞단의 ingress 문제다.
+- core/service는 GRPCRoute를 알 필요가 없다.
+- 따라서 지금 boundary를 고정해 두면 나중에 Gateway API를 붙여도 adapter/infra 영역만 바뀐다.
+
+### Istio 실험
+
+- Istio는 현재 확정 대상이 아니다.
+- mTLS, mesh routing, retry policy 등은 transport/infra concern이다.
+- 현재 코드에는 이를 전제로 한 import, config, policy를 넣지 않는다.
+
+결론적으로 지금은 “plain gRPC adapter가 가능하다” 수준이면 충분하고, mesh는 나중 문제다.
+
+## 이번 단계에서 확정하는 것
+
+- `service` 계층은 gRPC server 구현을 소유하지 않는다.
+- `service` 계층은 local/in-process와 gRPC adapter가 함께 사용할 인터페이스를 제공한다.
+- `transport/grpc`는 service 인터페이스를 호출하는 adapter로만 남긴다.
+- `cmd`는 concrete transport가 아니라 service 인터페이스에 붙는다.
+
+## Important Clarification
+
+현재 `service`는 일부 protobuf 타입을 반환하는 app contract를 사용한다.
+
+- 이 상태는 현재 문서 기준선에서 허용된 과도기적 app contract다.
+- 즉 "`service`가 protobuf 타입을 다룬다"는 사실만으로 transport 경계가 다시 무너졌다고 해석하지 않는다.
+- 현재 단계의 핵심은 gRPC server import와 transport lifecycle이 `service`를 오염하지 않게 하는 것이다.
+
+다만 이것이 최종 목표는 아니다.
+
+- 장기적으로는 protobuf-neutral 내부 DTO 또는 더 엄격한 contract 분리가 후속 선택지가 될 수 있다.
+- 현재 문서는 그 목표를 미리 달성했다고 주장하지 않는다.
+
+## Deferred Work
+
+- 최종 proto 파일 위치와 api-protos 흡수 완료 형태
+- syncfolders용 gRPC contract 최종안
+- Istio/mTLS 내부 통신 정책
+- Gateway API/GRPCRoute 배치 방식
+- core에서 proto DTO를 완전히 제거할지 여부
+
+특히 마지막 항목은 이번 단계의 비목표다. 현재는 “gRPC import가 service/core를 오염하지 않게 하는 것”이 우선이고, proto message를 더 중립적인 내부 DTO로 분리하는 문제는 후속 단계로 둔다.


### PR DESCRIPTION
## What changed
Documents the first transport boundary pass and the current proto ownership baseline on top of the transport-boundary code split.

- updates `README.md` to reflect the current baseline
- adds `transport_boundary.md`
- adds `proto_contract_ownership.md`
- adds the narrow remote RPC surface note
- adds Phase 1 / Phase 2 proto canonicalization notes

## Why it changed
The code boundary pass is already present, but the repository still needed a small set of documents that describe what is complete, what is still transitional, and what remains deferred.

## Impact
This does not change production semantics. It clarifies:
- `service` as app service boundary
- `transport/grpc` as adapter
- `protoio` as file I/O boundary
- current proto ownership is still working-state, not final
- current remote RPC surface is deliberately narrow

## Validation
- docs-only change
- reviewed against the staged transport-boundary code split
