### PR TITLE
[codex] add boundary follow-up notes

### DIFF
--- a/docs/architecture/block_boundary_followup.md
+++ b/docs/architecture/block_boundary_followup.md
@@ -1,0 +1,86 @@
+# Block Boundary Follow-up
+
+## 현재 `block`의 외부 helper 의존 지점
+
+현재 `block` 패키지는 외부 generated proto helper 패키지 `api-protos/.../service`에 직접 의존한다.
+
+직접 의존 지점:
+
+- `block/fileblock.go`
+  - `ConvertMapToFileBlock`
+  - `SaveProtoToFile`
+- `block/merge.go`
+  - `MergeFileBlocksFromData`
+  - `SaveProtoToFile`
+
+이 helper들은 모두 `api-protos` generated module 내부의 수동 코드에 위치한다. 즉 `block`은 generated protobuf 타입만 쓰는 것이 아니라, 외부 helper 구현 계층까지 직접 알고 있다.
+
+## 왜 이게 구조 오염인지
+
+이 구조가 문제인 이유는 다음과 같다.
+
+- `block`은 core/domain에 가까운 조합 계층인데, 외부 helper 구현 패키지의 위치와 API를 알아야 한다.
+- helper 패키지는 계약(proto) 자체가 아니라 계약 주변의 구현 편의 코드다.
+- 따라서 `api-protos`의 helper 구조가 바뀌면 core에 가까운 `block`도 함께 흔들린다.
+- 직전 단계에서 transport/gRPC adapter를 core 밖으로 밀어냈지만, 현재 helper 의존은 여전히 core 쪽에 외부 구현 세부사항이 남아 있는 상태다.
+
+핵심은 "`block`이 protobuf message 타입을 쓰는 것"과 "`block`이 외부 helper 구현 패키지를 직접 import하는 것"을 구분해야 한다는 점이다. 이번 단계의 목표는 후자를 먼저 제거하는 것이다.
+
+## 왜 `api-protos` 흡수보다 이 단계를 먼저 하는지
+
+`api-protos` 흡수나 proto source of truth 단일화는 다음 범위를 동반한다.
+
+- proto 파일 위치 재배치
+- generation 경로 재정의
+- import 경로 정리
+- generated code 기준선 정리
+
+이 작업은 범위가 크고, 지금 턴의 핵심 질문인 "`block`의 외부 helper 직접 의존 제거"보다 넓다.
+
+반면 이번 단계는 더 작은 경계 정리다.
+
+- `block`이 외부 helper 구현을 직접 알지 않게 만든다.
+- 도메인에 가까운 변환/병합 책임을 `tori` 내부로 되돌린다.
+- 입출력 책임을 별도 패키지로 분리한다.
+
+이 단계를 먼저 하면, 나중에 `api-protos`를 흡수하더라도 `block`이 helper 구조에 덜 묶여 있어 후속 작업이 작아진다.
+
+## 이번 턴에서 `block` 안으로 가져오는 책임
+
+이번 단계에서 `block` 내부로 가져오는 책임은 다음이다.
+
+- row map -> `pb.FileBlock` 변환
+- 여러 `*pb.FileBlock` -> `*pb.DataBlock` 병합
+
+이 둘은 `block`이 이미 소유하고 있는 조합 책임과 가깝다.
+
+- `rules` 결과를 FileBlock으로 조직화하는 일
+- FileBlock들을 DataBlock으로 묶는 일
+
+따라서 이 책임은 외부 helper보다 `block` 안에 있는 편이 자연스럽다.
+
+## 이번 턴에서 별도 패키지로 뺄 책임
+
+이번 단계에서 별도 `protoio` 패키지로 분리하는 책임은 다음이다.
+
+- protobuf marshal/unmarshal
+- 파일 저장/로드
+
+이 책임은 도메인 조합이 아니라 입출력이다. 따라서 `block` 내부에 계속 두는 것보다 분리된 패키지에 두는 편이 경계가 더 명확하다.
+
+이번 단계의 `protoio`는 작은 범위로 유지한다.
+
+- `SaveMessage`
+- `LoadDataBlock`
+- 필요 시 후속 단계에서 `LoadFileBlock` 등 확장
+
+## 이번 턴에서 하지 않는 것
+
+- `api-protos` 흡수
+- proto 파일 재배치
+- generated code 경로 변경
+- protobuf message를 내부 DTO로 전면 치환
+- `block` 패키지 대규모 분해
+- transport/runtime 확장
+
+즉, 이번 단계는 helper 직접 import 제거에만 집중한다.

--- a/docs/architecture/protoio_boundary_followup.md
+++ b/docs/architecture/protoio_boundary_followup.md
@@ -1,0 +1,77 @@
+# ProtoIO Boundary Follow-up
+
+## 현재 `protoio`의 책임
+
+현재 `protoio`는 protobuf 파일 I/O 공통 경계다.
+
+현재 제공 책임:
+
+- `SaveMessage`
+  - protobuf message를 binary로 serialize 해서 파일로 저장
+- `LoadDataBlock`
+  - binary protobuf 파일을 읽어 `DataBlock`으로 역직렬화
+
+현재 `block`과 `service`는 이 경계를 공통으로 신뢰한다.
+
+- `block`
+  - `FileBlock`, `DataBlock` 저장에 `SaveMessage` 사용
+- `service`
+  - `DataBlock` 로드에 `LoadDataBlock` 사용
+
+즉 `protoio`는 도메인 조합이나 app orchestration이 아니라, protobuf 파일 저장/로드만 담당한다.
+
+## 왜 지금 `protoio` 테스트를 먼저 추가하는지
+
+직전 단계에서 `block`의 외부 helper 직접 의존을 제거하면서 protobuf 파일 I/O가 `protoio`로 모였다.
+
+이제 `service`와 `block`이 같은 I/O 경계를 공통으로 사용하므로, 이 경계를 직접 테스트로 잠그는 것이 먼저다.
+
+이 작업을 먼저 하는 이유:
+
+- `service`와 `block`의 간접 테스트에 의존하지 않고 `protoio` 책임을 직접 검증할 수 있다.
+- 저장/로드 실패가 났을 때 도메인 문제인지 I/O 경계 문제인지 분리하기 쉬워진다.
+- 후속 단계에서 proto 재배치나 `api-protos` 흡수를 하더라도, 파일 I/O 기준선이 먼저 고정된다.
+
+## 무엇을 `protoio` 테스트에서 검증하고, 무엇은 검증하지 않는지
+
+직접 검증:
+
+- protobuf message를 binary 파일로 저장할 수 있는지
+- 저장한 `DataBlock`을 다시 로드할 수 있는지
+- `SaveMessage`가 `FileBlock` 같은 다른 protobuf message에도 공통으로 동작하는지
+- 존재하지 않는 파일 또는 잘못된 바이너리 입력에서 적절히 에러가 나는지
+
+직접 검증하지 않음:
+
+- `FileBlock`/`DataBlock` 조합 의미론
+  - `block` 책임
+- timestamp 기반 `GetDataBlock` 의미론
+  - `service` 책임
+- gRPC request/response shape
+  - `transport/grpc` 책임
+- textproto 저장
+  - 현재 `protoio`가 공식적으로 제공하는 경로가 아님
+
+## `service` / `block` / `protoio` 경계 정리
+
+- `protoio`
+  - protobuf binary 파일 저장/로드
+- `block`
+  - row map -> `FileBlock`
+  - `FileBlock[]` -> `DataBlock`
+- `service`
+  - app orchestration
+  - `db`/`block`/`protoio`를 조합한 local/in-process service path
+
+즉 `protoio`는 protobuf 파일 I/O boundary이고, 조합/정책을 소유하지 않는다.
+
+## 이번 턴에서 하지 않는 것
+
+- `protoio` API 확대
+- `LoadFileBlock` 같은 새 API 추가
+- text/binary 복수 형식 지원 추가
+- `api-protos` 흡수
+- proto source of truth 단일화
+- `service`/`block` 리팩터 확대
+
+이번 단계는 현재 `protoio` 책임을 테스트로 고정하는 작은 후속 정리다.

--- a/docs/architecture/service_test_boundary_followup.md
+++ b/docs/architecture/service_test_boundary_followup.md
@@ -1,0 +1,85 @@
+# Service Test Boundary Follow-up
+
+## 현재 `service/service_test.go`의 문제
+
+기존 `service/service_test.go`는 현재 구조 기준선과 맞지 않는 오래된 흔적을 많이 포함하고 있었다.
+
+- 외부 helper 패키지 `api-protos/.../service`를 직접 import했다.
+- 현재 `service` 책임이 아닌 `block` 생성/병합 책임까지 같이 검증했다.
+- `db` 패키지의 파일 유틸(`FileExistsExact`, `SearchFilesByPattern`, `DeleteFiles*`)을 `service` 테스트에서 검증했다.
+- 더 이상 존재하지 않는 오래된 타입/contract(`DataBlockServiceServerImpl`)에 의존했다.
+- transport/gRPC 이전 구조의 흔적이 남아 현재 `service` 기준선을 흐렸다.
+
+즉 이 파일은 현재 `service`의 테스트라기보다, 과거에 `service` 주변에 붙어 있던 여러 책임의 잔존물 모음에 가까웠다.
+
+## 어떤 부분이 현재 `service` 책임과 맞고, 어떤 부분이 과거 흔적인지
+
+현재 `service` 책임과 맞는 항목:
+
+- `DataBlockCliService.GetDataBlock`의 timestamp 기반 의미론
+- `DataBlockCliService.SaveFolders` / `SyncFolders`가 현재 app service 경로로 동작하는지
+- `SaveDataBlockToTextFile`
+- `LoadDataBlock`
+
+과거 흔적 또는 다른 패키지 책임인 항목:
+
+- `FileExistsExact`, `SearchFilesByPattern`, `DeleteFiles*`
+  - 현재는 `db/fs.go` 책임
+- `GenerateDataBlock`, `GenerateFileBlock`
+  - 현재는 `block` 책임
+- 외부 helper를 통한 proto load/save 검증
+  - 현재는 `protoio` 책임
+- `DataBlockServiceServerImpl`
+  - 현재 구조에는 없는 과거 transport/server 흔적
+
+## 왜 이번 턴에서 테스트를 먼저 정리해야 하는지
+
+지금 단계에서 중요한 것은 테스트 수를 유지하는 것이 아니라, 테스트 기준선이 현재 구조를 올바르게 반영하게 만드는 것이다.
+
+오래된 테스트가 남아 있으면 다음 문제가 생긴다.
+
+- 현재 구조를 잘못 이해하게 만든다.
+- 실제 경계 정리가 끝났는데도 “깨진 계약”처럼 보이게 만든다.
+- 어떤 실패가 regression이고 어떤 실패가 obsolete test인지를 구분하기 어렵게 만든다.
+
+따라서 이번 턴에서는 먼저 `service` 테스트를 현재 구조 기준선에 맞게 줄이고, 필요한 의미론만 남기는 편이 맞다.
+
+## 이번 턴에서 유지한 테스트
+
+- `GetDataBlock`의 현재 의미론
+  - timestamp 없음
+  - client timestamp가 과거
+  - 동일 timestamp
+  - client timestamp가 미래
+- `SaveDataBlockToTextFile`
+- `LoadDataBlock`
+- `SaveFolders` + `SyncFolders`를 통한 local/in-process app service 경로의 최소 통합 확인
+
+## 삭제/축소/이동한 테스트
+
+삭제:
+
+- `db/fs.go` 유틸 책임 테스트
+- `block` 책임 테스트
+- 오래된 `DataBlockServiceServerImpl` 기반 테스트
+- 외부 helper import를 전제로 한 테스트
+
+축소:
+
+- `SyncFolders` 관련 테스트는 service app path 확인에 필요한 최소 통합 테스트 1개만 유지
+
+이동:
+
+- `GenerateFileBlock`, `GenerateDataBlock` 관련 검증은 이미 `block` 테스트에서 담당
+- gRPC adapter 응답 shape는 `transport/grpc` 테스트에서 담당
+- protobuf 바이너리 I/O는 `protoio`를 통해 간접 사용하거나 후속으로 별도 테스트 가능
+
+## 이번 턴에서 하지 않는 것
+
+- `service` production code의 대규모 리팩터
+- `api-protos` 흡수
+- proto source of truth 단일화
+- `db` / `block` 테스트 재편 전반
+- transport/gRPC 테스트 확장
+
+이번 단계의 목적은 현재 구조 기준선에 맞지 않는 `service` 테스트 흔적을 걷어내고, 현재 `service` 책임에 맞는 최소 세트를 남기는 것이다.

--- a/docs/architecture/transport_refactor_plan.md
+++ b/docs/architecture/transport_refactor_plan.md
@@ -1,0 +1,78 @@
+# Transport Refactor Plan
+
+## 목표
+
+이번 단계의 목표는 최종 네트워크 구조를 확정하는 것이 아니라, transport 경계를 먼저 고정하는 것이다.
+
+구체 목표:
+
+- `service`를 transport-agnostic 하게 유지
+- gRPC를 adapter로 분리
+- local/in-process 호출을 정상 경로로 인정
+- 향후 Kubernetes, Gateway API, Istio 변경이 core를 흔들지 않게 만들기
+
+## 단계별 작업 계획
+
+### 1. 현재 경계 기록
+
+- 현재 `service`, `cmd`, `block`, `db`의 역할을 재정리
+- gRPC/server 흔적과 local/in-process 호출 경로를 문서화
+
+### 2. service 인터페이스 명시
+
+- `cmd`와 gRPC adapter가 함께 사용할 최소 service interface를 도입
+- concrete type 의존보다 interface 의존을 우선
+
+### 3. gRPC adapter 분리
+
+- `service` 패키지 안의 gRPC server adapter 흔적을 `transport/grpc`로 이동
+- adapter는 request/response 변환과 service 호출만 담당
+
+### 4. local/in-process 경로 유지
+
+- `cmd`는 별도 transport 없이 service 인터페이스를 직접 호출
+- local adapter는 현재 단계에서 “in-process direct call”을 기준선으로 둠
+
+### 5. 후속 단계 준비
+
+- proto 흡수 및 generated code 경로 정리는 별도 작은 단계로 분리
+- `block`의 proto helper 직접 의존은 후속 경계 정리 대상으로 남김
+
+## 작은 diff 기준의 실제 정리안
+
+이번 단계에서 허용하는 실제 수정은 다음으로 제한한다.
+
+- 문서 2개 추가
+- `service`에 transport-agnostic interface 추가
+- gRPC adapter를 `transport/grpc` 패키지로 분리
+- `cmd`가 concrete type 대신 service interface에 붙도록 조정
+
+이번 단계에서 하지 않는 것:
+
+- proto 파일 재배치
+- generated code 재생성
+- syncfolders gRPC 구현 확장
+- 대규모 패키지 이동
+- transport/storage DTO 전면 재설계
+
+## 위험요소
+
+- `service` 테스트는 이미 오래된 transport contract 잔존물과 섞여 있어, 이번 단계만으로 전체 green은 되지 않을 수 있다.
+- `block`이 외부 generated helper에 직접 붙어 있어 transport 경계가 완전히 닫히지는 않는다.
+- 현재 `DataBlock` 반환 타입이 proto message이므로, service가 완전히 protobuf-neutral 하다고 말할 수는 없다.
+
+## 비목표
+
+- gRPC 제거
+- Istio 전제 구조 도입
+- Gateway API 전제 코드 도입
+- production-grade server lifecycle 완성
+- mTLS 정책 확정
+- syncfolders/DataBlock 전체 API 재설계
+
+## 이번 단계 성공 기준
+
+- `service`가 `google.golang.org/grpc`를 import하지 않는다.
+- gRPC adapter 코드가 `transport/grpc`에 분리된다.
+- `cmd`가 service interface 경유 local/in-process 경로를 사용한다.
+- 문서에 왜 이렇게 하는지와 아직 확정하지 않는 범위가 남는다.


### PR DESCRIPTION
## What changed
Adds the remaining small follow-up notes around the transport-boundary split.

- `block_boundary_followup.md`
- `protoio_boundary_followup.md`
- `service_test_boundary_followup.md`
- `transport_refactor_plan.md`

## Why it changed
These notes do not introduce new architecture. They explain the immediate follow-up reasoning behind the already-split boundaries, tests, and package responsibilities.

## Impact
Docs-only. This makes the recent code slices easier to review in order:
- why block helper ownership moved inward
- why protoio is treated as file I/O boundary
- why old service tests were reduced to current-boundary tests
- how the first transport-boundary pass was intended to be phased

## Validation
- docs-only change
