### PR TITLE
[codex] Add Buf proto lint to Tori CI

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -6,6 +6,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  proto-lint:
+    name: Proto Lint (Buf)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Buf lint
+        uses: bufbuild/buf-action@v1
+        with:
+          input: protos
+          lint: true
+
   core-baseline:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closed because Tori follows a single-branch workflow. Commit `bb8b42d` was fast-forwarded directly to `master`.